### PR TITLE
Add spiffe enabled directive

### DIFF
--- a/spiffe-support/src/http/modules/ngx_http_proxy_module.c
+++ b/spiffe-support/src/http/modules/ngx_http_proxy_module.c
@@ -672,12 +672,12 @@ static ngx_command_t  ngx_http_proxy_commands[] = {
       NGX_HTTP_LOC_CONF_OFFSET,
       offsetof(ngx_http_proxy_loc_conf_t, upstream.ssl_verify),
       NULL },
-    { ngx_string("proxy_ssl_spiffe_sock"),
-        NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_FLAG,
-        ngx_conf_set_str_slot,
-        NGX_HTTP_LOC_CONF_OFFSET,
-        offsetof(ngx_http_proxy_loc_conf_t, upstream.ssl_spiffe_sock),
-        NULL },
+    { ngx_string("proxy_ssl_spiffe"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_proxy_loc_conf_t, upstream.ssl_spiffe),
+      NULL }, 
 	{ ngx_string("proxy_ssl_spiffe_accept"),
         NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF| NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|(NGX_CONF_TAKE1|NGX_CONF_TAKE2|NGX_CONF_TAKE3   \
                               |NGX_CONF_TAKE4|NGX_CONF_TAKE5|NGX_CONF_TAKE6|NGX_CONF_TAKE7),
@@ -2917,6 +2917,7 @@ ngx_http_proxy_create_loc_conf(ngx_conf_t *cf)
     conf->upstream.ssl_session_reuse = NGX_CONF_UNSET;
     conf->upstream.ssl_server_name = NGX_CONF_UNSET;
     conf->upstream.ssl_verify = NGX_CONF_UNSET;
+    conf->upstream.ssl_spiffe = NGX_CONF_UNSET;    
     conf->upstream.ssl_spiffe_accept = NGX_CONF_UNSET_PTR;    
     conf->ssl_verify_depth = NGX_CONF_UNSET_UINT;
     conf->ssl_passwords = NGX_CONF_UNSET_PTR;    
@@ -3250,8 +3251,8 @@ ngx_http_proxy_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
     ngx_conf_merge_value(conf->upstream.ssl_verify,
                               prev->upstream.ssl_verify, 0);
 
-    ngx_conf_merge_str_value(conf->upstream.ssl_spiffe_sock,
-                              prev->upstream.ssl_spiffe_sock, "");
+    ngx_conf_merge_value(conf->upstream.ssl_spiffe,
+                              prev->upstream.ssl_spiffe, 0);
     ngx_conf_merge_ptr_value(conf->upstream.ssl_spiffe_accept,
                               prev->upstream.ssl_spiffe_accept, NULL);
 

--- a/spiffe-support/src/http/modules/ngx_http_ssl_module.c
+++ b/spiffe-support/src/http/modules/ngx_http_ssl_module.c
@@ -232,13 +232,13 @@ static ngx_command_t  ngx_http_ssl_commands[] = {
       ngx_conf_set_flag_slot,
       NGX_HTTP_SRV_CONF_OFFSET,
       offsetof(ngx_http_ssl_srv_conf_t, stapling_verify),
-      NULL },  
-    { ngx_string("ssl_spiffe_sock"),
-        NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_CONF_TAKE1,
-        ngx_conf_set_str_slot,
-        NGX_HTTP_SRV_CONF_OFFSET,
-        offsetof(ngx_http_ssl_srv_conf_t, ssl_spiffe_sock),
-        NULL },
+      NULL },     
+    { ngx_string("ssl_spiffe"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot,
+      NGX_HTTP_SRV_CONF_OFFSET,
+      offsetof(ngx_http_ssl_srv_conf_t, ssl_spiffe),
+      NULL },
 	{ ngx_string("ssl_spiffe_accept"),
         NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|(NGX_CONF_TAKE1|NGX_CONF_TAKE2|NGX_CONF_TAKE3   \
                               |NGX_CONF_TAKE4|NGX_CONF_TAKE5|NGX_CONF_TAKE6|NGX_CONF_TAKE7),
@@ -555,7 +555,7 @@ ngx_http_ssl_create_srv_conf(ngx_conf_t *cf)
      *     sscf->ciphers = { 0, NULL };
      *     sscf->shm_zone = NULL;
      *     sscf->stapling_file = { 0, NULL };
-     *     sscf->stapling_responder = { 0, NULL };
+     *     sscf->stapling_responder = { 0, NULL }; 
      */
 
     sscf->enable = NGX_CONF_UNSET;
@@ -572,6 +572,7 @@ ngx_http_ssl_create_srv_conf(ngx_conf_t *cf)
     sscf->session_ticket_keys = NGX_CONF_UNSET_PTR;
     sscf->stapling = NGX_CONF_UNSET;
     sscf->stapling_verify = NGX_CONF_UNSET;
+    sscf->ssl_spiffe = NGX_CONF_UNSET;
     sscf->ssl_spiffe_accept = NGX_CONF_UNSET_PTR;
 
     return sscf;
@@ -612,10 +613,10 @@ ngx_http_ssl_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
 
     ngx_conf_merge_uint_value(conf->verify, prev->verify, 0);
 
-    ngx_conf_merge_str_value(conf->ssl_spiffe_sock,
-                              prev->ssl_spiffe_sock, "");
+    ngx_conf_merge_value(conf->ssl_spiffe, 
+                         prev->ssl_spiffe, 0);
     ngx_conf_merge_ptr_value(conf->ssl_spiffe_accept,
-                              prev->ssl_spiffe_accept, NULL);
+                         prev->ssl_spiffe_accept, NULL);
 
     ngx_conf_merge_uint_value(conf->verify_depth, prev->verify_depth, 1);
 
@@ -763,7 +764,7 @@ ngx_http_ssl_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
 
     // verify if spiffe sock is enabled
     //
-    if (conf->ssl_spiffe_sock.len != 0) {
+    if (conf->ssl_spiffe) {
         // validate certificate
         if (ngx_ssl_spiffe_id_verification(cf, &conf->ssl,
                                        conf->ssl_spiffe_accept)                                       

--- a/spiffe-support/src/http/modules/ngx_http_ssl_module.h
+++ b/spiffe-support/src/http/modules/ngx_http_ssl_module.h
@@ -59,8 +59,7 @@ typedef struct {
     ngx_uint_t                      line;
 
     ngx_flag_t 						ssl_spiffe;
-    ngx_str_t						ssl_spiffe_sock;
-    ngx_array_t 				    *ssl_spiffe_accept;
+    ngx_array_t 				   *ssl_spiffe_accept;
 } ngx_http_ssl_srv_conf_t;
 
 

--- a/spiffe-support/src/http/ngx_http_upstream.c
+++ b/spiffe-support/src/http/ngx_http_upstream.c
@@ -1725,7 +1725,7 @@ ngx_http_upstream_ssl_handshake(ngx_http_request_t *r, ngx_http_upstream_t *u,
     if (c->ssl->handshaked) {
         // verify if spiffe validation is enabled
         //
-        if (u->conf->ssl_spiffe_sock.len != 0) {  
+        if (u->conf->ssl_spiffe) {  
             // verify SPIFFE ID using accepted list
             if (ngx_ssl_check_spiffe_id(c, u->conf->ssl_spiffe_accept)                                       
                 != NGX_OK)
@@ -1744,7 +1744,7 @@ ngx_http_upstream_ssl_handshake(ngx_http_request_t *r, ngx_http_upstream_t *u,
                 goto failed;
             }
 
-            if (u->conf->ssl_spiffe_sock.len == 0 &&
+            if (!u->conf->ssl_spiffe &&
                 ngx_ssl_check_host(c, &u->ssl_name) != NGX_OK) {
 
                 ngx_log_error(NGX_LOG_ERR, c->log, 0,

--- a/spiffe-support/src/http/ngx_http_upstream.h
+++ b/spiffe-support/src/http/ngx_http_upstream.h
@@ -229,7 +229,7 @@ typedef struct {
     ngx_http_complex_value_t        *ssl_name;
     ngx_flag_t                       ssl_server_name;
     ngx_flag_t                       ssl_verify;
-    ngx_str_t						 ssl_spiffe_sock;
+    ngx_flag_t						 ssl_spiffe;
     ngx_array_t 				    *ssl_spiffe_accept;
 
 #endif


### PR DESCRIPTION
Add proxy_ssl_spiffe and ssl_spiffe to enable spiffe_id validation to credentials, 
Removed proxy_ssl_spiffe_sock it will be used by another module.