### PR TITLE
Add nginx module to fetch SVIDs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.9
+FROM golang:1.10
 
 RUN apt-get update && apt-get -y install \
     curl unzip git build-essential autoconf automake dh-autoreconf libtool pkg-config g++

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:xenial
+FROM golang:1.9
 
 RUN apt-get update && apt-get -y install \
     curl unzip git build-essential autoconf automake dh-autoreconf libtool pkg-config g++

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
-docker = docker run -v $(docker_volume) -it $(docker_image)
+docker = docker run -v $(docker_volume) -p 80:80 -it $(docker_image)
 docker_volume := $(shell echo $${PWD}):/opt/nginx-dev
 docker_image = spiffe-nginx:latest
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
-docker = docker run -v $(docker_volume) -p 80:80 -it $(docker_image)
+docker = docker run -v $(docker_volume) --name spiffe-nginx -p 80:80 -it $(docker_image)
 docker_volume := $(shell echo $${PWD}):/opt/nginx-dev
 docker_image = spiffe-nginx:latest
 

--- a/build.sh
+++ b/build.sh
@@ -40,9 +40,8 @@ case $1 in
 		set -x
 		./configure $_config \
 			--with-debug \
-			--with-http_ssl_module \
-			--with-stream_ssl_module \
-			--add-module=/go/src/github.com/spiffe/ngx_http_fetch_spiffe_certs_module
+			--add-module=/go/src/github.com/spiffe/ngx_http_fetch_spiffe_certs_module \
+			--with-http_ssl_module
 		set +x
 		;;
 	make)

--- a/build.sh
+++ b/build.sh
@@ -38,7 +38,6 @@ case $1 in
 		setup_nginx
 		cd ${ngx_dir}
 		set -x
-		CFLAGS="-g -O0" \
 		./configure $_config \
 			--with-debug \
 			--with-http_ssl_module \

--- a/install_spire.sh
+++ b/install_spire.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+declare -r SPIRE_VERSION="0.4"
+declare -r SPIRE_URL="https://github.com/spiffe/spire/releases/download/${SPIRE_VERSION}/spire-${SPIRE_VERSION}-linux-x86_64-glibc.tar.gz"
+declare -r SPIRE_DIR="/opt/spire"
+
+curl --progress-bar --location ${SPIRE_URL} | tar xzf -
+rm -rf ${SPIRE_DIR}
+mv -v spire-${SPIRE_VERSION} /opt/spire/
+chmod -R 777 ${SPIRE_DIR}
+mkdir ${SPIRE_DIR}/.data
+cp ./spire_server.conf ${SPIRE_DIR}/conf/server/server.conf
+cp ./spire_agent.conf ${SPIRE_DIR}/conf/agent/agent.conf

--- a/install_spire.sh
+++ b/install_spire.sh
@@ -9,5 +9,7 @@ rm -rf ${SPIRE_DIR}
 mv -v spire-${SPIRE_VERSION} /opt/spire/
 chmod -R 777 ${SPIRE_DIR}
 mkdir ${SPIRE_DIR}/.data
+
+# Updating config files is needed in version 0.4
 cp ./spire_server.conf ${SPIRE_DIR}/conf/server/server.conf
 cp ./spire_agent.conf ${SPIRE_DIR}/conf/agent/agent.conf

--- a/nginx.sh
+++ b/nginx.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+export LD_LIBRARY_PATH="/go/src/github.com/spiffe/ngx_http_fetch_spiffe_certs_module:$LD_LIBRARY_PATH"
+exec ./nginx -c /opt/nginx-dev/spiffe-support/$1

--- a/ngx_http_fetch_spiffe_certs_module/Makefile
+++ b/ngx_http_fetch_spiffe_certs_module/Makefile
@@ -1,0 +1,22 @@
+.PHONY: all utils build clean distclean
+
+build:
+	go build \
+	-buildmode=c-shared \
+	-o ngx_http_fetch_spiffe_certs_module.so \
+	ngx_http_fetch_spiffe_certs_module.go
+
+all: utils vendor build
+
+utils:
+	go get github.com/Masterminds/glide
+
+vendor: glide.yaml glide.lock
+	glide install
+
+clean:
+	go clean
+
+distclean:
+	go clean -i
+	rm -rf vendor dist

--- a/ngx_http_fetch_spiffe_certs_module/config
+++ b/ngx_http_fetch_spiffe_certs_module/config
@@ -1,0 +1,3 @@
+ngx_addon_name=ngx_http_fetch_spiffe_certs_module
+HTTP_MODULES="$HTTP_MODULES ngx_http_fetch_spiffe_certs_module"
+NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_http_fetch_spiffe_certs_module.c"

--- a/ngx_http_fetch_spiffe_certs_module/glide.lock
+++ b/ngx_http_fetch_spiffe_certs_module/glide.lock
@@ -1,0 +1,62 @@
+hash: 496bfc02ffc0bf3a0e2d80d0d92b70efba9d15d38f97660068d6e0117afb6757
+updated: 2018-03-02T03:37:35.730719172Z
+imports:
+- name: github.com/golang/protobuf
+  version: bbd03ef6da3a115852eaf24c8a1c46aeb39aa175
+  subpackages:
+  - proto
+  - ptypes
+  - ptypes/any
+  - ptypes/duration
+  - ptypes/timestamp
+- name: github.com/spiffe/spire
+  version: 416474f9f0ea4be10c409c82f86120615a28e9af
+  subpackages:
+  - proto/api/workload
+- name: golang.org/x/net
+  version: 22ae77b79946ea320088417e4d50825671d82d57
+  subpackages:
+  - context
+  - http2
+  - http2/hpack
+  - idna
+  - internal/timeseries
+  - lex/httplex
+  - trace
+- name: golang.org/x/text
+  version: 0b0b1f509072617b86d90971b51da23cc52694f2
+  subpackages:
+  - secure/bidirule
+  - transform
+  - unicode/bidi
+  - unicode/norm
+- name: google.golang.org/genproto
+  version: 2c5e7ac708aaa719366570dd82bda44541ca2a63
+  subpackages:
+  - googleapis/rpc/status
+- name: google.golang.org/grpc
+  version: 8e4536a86ab602859c20df5ebfd0bd4228d08655
+  subpackages:
+  - balancer
+  - balancer/base
+  - balancer/roundrobin
+  - codes
+  - connectivity
+  - credentials
+  - encoding
+  - encoding/proto
+  - grpclb/grpc_lb_v1/messages
+  - grpclog
+  - internal
+  - keepalive
+  - metadata
+  - naming
+  - peer
+  - resolver
+  - resolver/dns
+  - resolver/passthrough
+  - stats
+  - status
+  - tap
+  - transport
+testImports: []

--- a/ngx_http_fetch_spiffe_certs_module/glide.yaml
+++ b/ngx_http_fetch_spiffe_certs_module/glide.yaml
@@ -1,0 +1,5 @@
+package: github.com/spiffe/ngx_http_fetch_spiffe_certs_module
+import:
+- package: google.golang.org/grpc
+  version: ^1.10.0
+- package: github.com/spiffe/spire/proto/api/workload

--- a/ngx_http_fetch_spiffe_certs_module/ngx_http_fetch_spiffe_certs_module.c
+++ b/ngx_http_fetch_spiffe_certs_module/ngx_http_fetch_spiffe_certs_module.c
@@ -7,49 +7,45 @@ typedef struct {
     ngx_str_t svid_file_path;
     ngx_str_t svid_key_file_path;
     ngx_str_t svid_bundle_file_path;
-} ngx_http_ssl_spiffe_srv_conf_t;
+} ngx_http_fetch_spiffe_certs_srv_conf_t;
 
 static ngx_command_t ngx_http_fetch_spiffe_certs_commands[] = {
     { ngx_string("ssl_spiffe_sock"),
         NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_CONF_TAKE1,
         ngx_conf_set_str_slot,
         NGX_HTTP_SRV_CONF_OFFSET,
-        offsetof(ngx_http_ssl_spiffe_srv_conf_t, ssl_spiffe_sock),
+        offsetof(ngx_http_fetch_spiffe_certs_srv_conf_t, ssl_spiffe_sock),
         NULL },
     { ngx_string("svid_file_path"),
         NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_CONF_TAKE1,
         ngx_conf_set_str_slot,
         NGX_HTTP_SRV_CONF_OFFSET,
-        offsetof(ngx_http_ssl_spiffe_srv_conf_t, svid_file_path),
+        offsetof(ngx_http_fetch_spiffe_certs_srv_conf_t, svid_file_path),
         NULL },
     { ngx_string("svid_key_file_path"),
         NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_CONF_TAKE1,
         ngx_conf_set_str_slot,
         NGX_HTTP_SRV_CONF_OFFSET,
-        offsetof(ngx_http_ssl_spiffe_srv_conf_t, svid_key_file_path),
+        offsetof(ngx_http_fetch_spiffe_certs_srv_conf_t, svid_key_file_path),
         NULL },
     { ngx_string("svid_bundle_file_path"),
         NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_CONF_TAKE1,
         ngx_conf_set_str_slot,
         NGX_HTTP_SRV_CONF_OFFSET,
-        offsetof(ngx_http_ssl_spiffe_srv_conf_t, svid_bundle_file_path),
+        offsetof(ngx_http_fetch_spiffe_certs_srv_conf_t, svid_bundle_file_path),
         NULL },
       ngx_null_command
 };
 
 static void * ngx_http_fetch_spiffe_certs_create_conf(ngx_conf_t *cf)
 {
-    ngx_http_ssl_spiffe_srv_conf_t  *scf;
+    ngx_http_fetch_spiffe_certs_srv_conf_t  *scf;
 
-    scf = ngx_pcalloc(cf->pool, sizeof(ngx_http_ssl_spiffe_srv_conf_t));
-    if (scf == NULL) {
-        return NULL;
-    }
-
+    scf = ngx_pcalloc(cf->pool, sizeof(ngx_http_fetch_spiffe_certs_srv_conf_t));
     return scf;
 }
 
-static ngx_int_t ngx_http_fetch_spiffe_certs(ngx_http_ssl_spiffe_srv_conf_t *conf) {
+static ngx_int_t ngx_http_fetch_spiffe_certs(ngx_http_fetch_spiffe_certs_srv_conf_t *conf) {
     void *go_module = dlopen("ngx_http_fetch_spiffe_certs_module.so", RTLD_LAZY);
     if (!go_module) {
         fprintf(stderr, "go module not found");
@@ -67,8 +63,8 @@ static ngx_int_t ngx_http_fetch_spiffe_certs(ngx_http_ssl_spiffe_srv_conf_t *con
 
 static char * ngx_http_fetch_spiffe_certs_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
 {
-    ngx_http_ssl_spiffe_srv_conf_t *prev = parent;
-    ngx_http_ssl_spiffe_srv_conf_t *conf = child;
+    ngx_http_fetch_spiffe_certs_srv_conf_t *prev = parent;
+    ngx_http_fetch_spiffe_certs_srv_conf_t *conf = child;
 
     ngx_conf_merge_str_value(conf->ssl_spiffe_sock, prev->ssl_spiffe_sock, "");
     ngx_conf_merge_str_value(conf->svid_file_path, prev->svid_file_path, "");

--- a/ngx_http_fetch_spiffe_certs_module/ngx_http_fetch_spiffe_certs_module.c
+++ b/ngx_http_fetch_spiffe_certs_module/ngx_http_fetch_spiffe_certs_module.c
@@ -56,20 +56,13 @@ static ngx_int_t ngx_http_fetch_spiffe_certs(ngx_http_ssl_spiffe_srv_conf_t *con
         return NGX_ERROR;
     }
 
-    u_char* (*fun)(u_char *, u_char *, u_char *, u_char *) = (u_char* (*)(u_char *, u_char *, u_char *, u_char *)) dlsym(go_module, "FetchSvids");
-    u_char* err = fun(conf->ssl_spiffe_sock.data,
+    int (*fun)(u_char *, u_char *, u_char *, u_char *) = (int (*)(u_char *, u_char *, u_char *, u_char *)) dlsym(go_module, "FetchSvids");
+    fun(conf->ssl_spiffe_sock.data,
                             conf->svid_file_path.data,
                             conf->svid_key_file_path.data,
                             conf->svid_bundle_file_path.data);
 
-    ngx_str_t ngx_err = { strlen(err), err };
-
-    if (ngx_err.data == "") {
-        return NGX_OK;
-    }
-    else {
-        return NGX_ERROR;
-    }
+    return NGX_OK;
 }
 
 static char * ngx_http_fetch_spiffe_certs_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)

--- a/ngx_http_fetch_spiffe_certs_module/ngx_http_fetch_spiffe_certs_module.c
+++ b/ngx_http_fetch_spiffe_certs_module/ngx_http_fetch_spiffe_certs_module.c
@@ -1,0 +1,113 @@
+#include <ngx_config.h>
+#include <ngx_core.h>
+#include <ngx_http.h>
+
+typedef struct {
+    ngx_str_t ssl_spiffe_sock;
+    ngx_str_t svid_file_path;
+    ngx_str_t svid_key_file_path;
+    ngx_str_t svid_bundle_file_path;
+} ngx_http_ssl_spiffe_srv_conf_t;
+
+static ngx_command_t ngx_http_fetch_spiffe_certs_commands[] = {
+    { ngx_string("ssl_spiffe_sock"),
+        NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_CONF_TAKE1,
+        ngx_conf_set_str_slot,
+        NGX_HTTP_SRV_CONF_OFFSET,
+        offsetof(ngx_http_ssl_spiffe_srv_conf_t, ssl_spiffe_sock),
+        NULL },
+    { ngx_string("svid_file_path"),
+        NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_CONF_TAKE1,
+        ngx_conf_set_str_slot,
+        NGX_HTTP_SRV_CONF_OFFSET,
+        offsetof(ngx_http_ssl_spiffe_srv_conf_t, svid_file_path),
+        NULL },
+    { ngx_string("svid_key_file_path"),
+        NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_CONF_TAKE1,
+        ngx_conf_set_str_slot,
+        NGX_HTTP_SRV_CONF_OFFSET,
+        offsetof(ngx_http_ssl_spiffe_srv_conf_t, svid_key_file_path),
+        NULL },
+    { ngx_string("svid_bundle_file_path"),
+        NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_CONF_TAKE1,
+        ngx_conf_set_str_slot,
+        NGX_HTTP_SRV_CONF_OFFSET,
+        offsetof(ngx_http_ssl_spiffe_srv_conf_t, svid_bundle_file_path),
+        NULL },
+      ngx_null_command
+};
+
+static void * ngx_http_fetch_spiffe_certs_create_conf(ngx_conf_t *cf)
+{
+    ngx_http_ssl_spiffe_srv_conf_t  *scf;
+
+    scf = ngx_pcalloc(cf->pool, sizeof(ngx_http_ssl_spiffe_srv_conf_t));
+    if (scf == NULL) {
+        return NULL;
+    }
+
+    return scf;
+}
+
+static ngx_int_t ngx_http_fetch_spiffe_certs(ngx_http_ssl_spiffe_srv_conf_t *conf) {
+    void *go_module = dlopen("ngx_http_fetch_spiffe_certs_module.so", RTLD_LAZY);
+    if (!go_module) {
+        fprintf(stderr, "go module not found");
+        return NGX_ERROR;
+    }
+
+    u_char* (*fun)(u_char *, u_char *, u_char *, u_char *) = (u_char* (*)(u_char *, u_char *, u_char *, u_char *)) dlsym(go_module, "FetchSvids");
+    u_char* err = fun(conf->ssl_spiffe_sock.data,
+                            conf->svid_file_path.data,
+                            conf->svid_key_file_path.data,
+                            conf->svid_bundle_file_path.data);
+
+    ngx_str_t ngx_err = { strlen(err), err };
+
+    if (ngx_err.data == "") {
+        return NGX_OK;
+    }
+    else {
+        return NGX_ERROR;
+    }
+}
+
+static char * ngx_http_fetch_spiffe_certs_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
+{
+    ngx_http_ssl_spiffe_srv_conf_t *prev = parent;
+    ngx_http_ssl_spiffe_srv_conf_t *conf = child;
+
+    ngx_conf_merge_str_value(conf->ssl_spiffe_sock, prev->ssl_spiffe_sock, "");
+    ngx_conf_merge_str_value(conf->svid_file_path, prev->svid_file_path, "");
+    ngx_conf_merge_str_value(conf->svid_key_file_path, prev->svid_key_file_path, "");
+    ngx_conf_merge_str_value(conf->svid_bundle_file_path, prev->svid_bundle_file_path, "");
+
+    ngx_http_fetch_spiffe_certs(conf);
+    return NGX_CONF_OK;
+}
+
+static ngx_http_module_t ngx_http_fetch_spiffe_certs_module_ctx = {
+    NULL,                                       /* preconfiguration */
+    NULL,                                       /* postconfiguration */
+    NULL,                                       /* create main configuration */
+    NULL,                                       /* init main configuration */
+    ngx_http_fetch_spiffe_certs_create_conf,    /* create server configuration */
+    ngx_http_fetch_spiffe_certs_merge_srv_conf, /* merge server configuration */
+    NULL,                                       /* create location configuration */
+    NULL                                        /* merge location configuration */
+};
+
+ngx_module_t ngx_http_fetch_spiffe_certs_module = {
+    NGX_MODULE_V1,
+    &ngx_http_fetch_spiffe_certs_module_ctx,  /* module context */
+    ngx_http_fetch_spiffe_certs_commands,     /* module directives */
+    NGX_HTTP_MODULE,                          /* module type */
+    NULL,                                     /* init master */
+    NULL,                                     /* init module */
+    NULL,                                     /* init process */
+    NULL,                                     /* init thread */
+    NULL,                                     /* exit thread */
+    NULL,                                     /* exit process */
+    NULL,                                     /* exit master */
+    NGX_MODULE_V1_PADDING
+};

--- a/ngx_http_fetch_spiffe_certs_module/ngx_http_fetch_spiffe_certs_module.go
+++ b/ngx_http_fetch_spiffe_certs_module/ngx_http_fetch_spiffe_certs_module.go
@@ -1,0 +1,174 @@
+package main
+
+import (
+	"C"
+)
+import (
+	"context"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/spiffe/spire/proto/api/workload"
+	"google.golang.org/grpc"
+)
+
+type fetchSpiffeCertsModule struct {
+	workloadClient        workload.WorkloadClient
+	workloadClientContext context.Context
+	svidFilePath          string
+	svidKeyFilePath       string
+	svidBundleFilePath    string
+}
+
+// main is required for the file to compile to an object.
+func main() {}
+
+//export FetchSvids
+func FetchSvids(sockAddr *C.char,
+	svidFilePath *C.char,
+	svidKeyFilePath *C.char,
+	svidBundleFilePath *C.char) *C.char {
+
+	workloadClient, ctx, _, err := createGrpcClient(C.GoString(sockAddr))
+	m := &fetchSpiffeCertsModule{
+		workloadClient:        workloadClient,
+		workloadClientContext: ctx,
+		svidFilePath:          C.GoString(svidFilePath),
+		svidKeyFilePath:       C.GoString(svidKeyFilePath),
+		svidBundleFilePath:    C.GoString(svidBundleFilePath)}
+
+	if err != nil {
+		log.Printf("error creating GRPC client: %v", err)
+		return C.CString(err.Error())
+	}
+
+	go m.fetchLoop()
+	return C.CString("")
+}
+
+func (m *fetchSpiffeCertsModule) fetchLoop() {
+	// Create channel for interrupt signal
+	interrupt := make(chan os.Signal, 1)
+	signal.Notify(interrupt, syscall.SIGINT, syscall.SIGTERM)
+
+	for {
+		// Fetch and dump certificates
+		ttl, err := m.dumpBundles()
+		if err != nil {
+			log.Printf("error dumping bundles: %v", err)
+			return
+		}
+
+		process, err := os.FindProcess(os.Getpid())
+		if err != nil {
+			log.Printf("error finding process: %v", err)
+			return
+		}
+		log.Printf("nginx PID is: %v", process.Pid)
+
+		// Create timer for TTL/2
+		timer := time.NewTimer(time.Second * time.Duration(ttl/2))
+
+		// Wait for either timer or interrupt signal
+		log.Printf("Will wait for TTL/2 (%d seconds)\n", ttl/2)
+		select {
+		case <-timer.C:
+			log.Print("Time is up! Will renew cert.\n")
+			// Continue
+		case <-interrupt:
+			log.Print("Interrupted! Will exit.\n")
+			return
+		}
+
+		err = process.Signal(syscall.SIGHUP)
+		if err != nil {
+			log.Printf("error sending signal: %v", err)
+			return
+		}
+	}
+}
+
+func createGrpcClient(addr string) (workloadClient workload.WorkloadClient, ctx context.Context, cancel context.CancelFunc, err error) {
+	ctx = context.Background()
+	ctx, cancel = context.WithCancel(ctx)
+
+	conn, err := grpc.Dial(addr,
+		grpc.WithInsecure(),
+		grpc.WithDialer(func(addr string, timeout time.Duration) (net.Conn, error) {
+			return net.DialTimeout("unix", addr, timeout)
+		}))
+
+	workloadClient = workload.NewWorkloadClient(conn)
+
+	return workloadClient, ctx, cancel, err
+}
+
+func (m *fetchSpiffeCertsModule) dumpBundles() (ttl int32, err error) {
+	bundles, err := m.workloadClient.FetchAllBundles(m.workloadClientContext, &workload.Empty{})
+	if err != nil {
+		return ttl, err
+	}
+
+	if len(bundles.Bundles) == 0 {
+		return ttl, errors.New("fetched zero bundles")
+	}
+
+	ttl = bundles.Ttl
+	log.Printf("TTL is: %v seconds\n", ttl)
+	log.Printf("Bundles found: %d\n", len(bundles.Bundles))
+
+	if len(bundles.Bundles) > 1 {
+		log.Print("Only certificates from the first bundle will be written")
+	}
+
+	// There may be more than one bundle, but we are interested in the first one only
+	bundle := bundles.Bundles[0]
+
+	svidKeyFile := m.svidKeyFilePath
+	svidFile := m.svidFilePath
+	svidBundleFile := m.svidBundleFilePath
+
+	svidPrivateKey := pem.EncodeToMemory(
+		&pem.Block{
+			Type:  "EC PRIVATE KEY",
+			Bytes: bundle.SvidPrivateKey})
+
+	svid := pem.EncodeToMemory(
+		&pem.Block{
+			Type:  "CERTIFICATE",
+			Bytes: bundle.Svid})
+
+	log.Printf("Writing: %v\n", svidKeyFile)
+	err = ioutil.WriteFile(svidKeyFile, append(svidPrivateKey, svid...), os.ModePerm)
+	if err != nil {
+		return ttl, fmt.Errorf("error writing file: %v\n%v", svidKeyFile, err)
+	}
+
+	log.Printf("Writing: %v\n", svidFile)
+	err = ioutil.WriteFile(svidFile, svid, os.ModePerm)
+	if err != nil {
+		return ttl, fmt.Errorf("error writing file: %v\n%v", svidFile, err)
+	}
+
+	svidBundle := pem.EncodeToMemory(
+		&pem.Block{
+			Type:  "CERTIFICATE",
+			Bytes: bundle.SvidBundle,
+		})
+
+	log.Printf("Writing: %v\n", svidBundleFile)
+	err = ioutil.WriteFile(svidBundleFile, svidBundle, os.ModePerm)
+	if err != nil {
+		return ttl, fmt.Errorf("error writing file: %v\n%v", svidBundleFile, err)
+	}
+
+	return ttl, nil
+}

--- a/spiffe-support/index.html
+++ b/spiffe-support/index.html
@@ -1,0 +1,8 @@
+<html>
+    <head>
+        <title>Welcome to SPIFFE!</title>
+    </head>
+    <body>
+        <h1>Welcome to SPIFFE!</h1>
+    </body>
+</html>

--- a/spiffe-support/nginx_blog.conf
+++ b/spiffe-support/nginx_blog.conf
@@ -20,10 +20,10 @@ http {
     ssl_verify_client on;
     ssl_certificate         /certs/blog_svid.pem;
     ssl_certificate_key     /certs/blog_svid_key.pem;
-    ssl_client_certificate  /certs/fe_svid_bundle.pem;
+    ssl_client_certificate  /certs/blog_svid_bundle.pem;
 
     ssl_spiffe on;
-    ssl_spiffe_accept spiffe://example.org/host/fe;
+    ssl_spiffe_accept spiffe://example.org/host/front-end;
 
     location / {
       root   html;

--- a/spiffe-support/nginx_blog.conf
+++ b/spiffe-support/nginx_blog.conf
@@ -1,0 +1,33 @@
+daemon off;
+pid /certs/nginx.pid;
+worker_processes 1;
+error_log /dev/stdout debug;
+events {
+  worker_connections 1024;
+}
+
+http {
+  server {
+    listen       8443 ssl;
+    server_name  localhost;
+
+    # Fetch SVIDs
+    ssl_spiffe_sock       /tmp/agent.sock;
+    svid_file_path        /certs/blog_svid.pem;
+    svid_key_file_path    /certs/blog_svid_key.pem;
+    svid_bundle_file_path /certs/blog_svid_bundle.pem;
+
+    ssl_verify_client on;
+    ssl_certificate         /certs/blog_svid.pem;
+    ssl_certificate_key     /certs/blog_svid_key.pem;
+    ssl_client_certificate  /certs/fe_svid_bundle.pem;
+
+    ssl_spiffe on;
+    ssl_spiffe_accept spiffe://example.org/host/fe;
+
+    location / {
+      root   html;
+      index  index.html index.htm;
+    }
+  }
+}

--- a/spiffe-support/nginx_fe.conf
+++ b/spiffe-support/nginx_fe.conf
@@ -1,0 +1,33 @@
+daemon off;
+worker_processes 1;
+error_log /dev/stdout debug;
+events {
+  worker_connections 1024;
+}
+
+http {
+  server {
+    listen      80;
+    server_name localhost;
+
+    # Fetch SVIDs
+    ssl_spiffe_sock       /tmp/agent.sock;
+    svid_file_path        /certs/fe_svid.pem;
+    svid_key_file_path    /certs/fe_svid_key.pem;
+    svid_bundle_file_path /certs/fe_svid_bundle.pem;
+
+    proxy_ssl_verify              on;
+    proxy_ssl_certificate         /certs/fe_svid.pem;
+    proxy_ssl_certificate_key     /certs/fe_svid_key.pem;
+    proxy_ssl_trusted_certificate /certs/blog_svid_bundle.pem;
+
+    proxy_ssl_spiffe on;
+    proxy_ssl_spiffe_accept spiffe://example.org/host/blog;
+
+    location / {
+      root   html;
+      index  index.html index.htm;
+      proxy_pass https://127.0.0.1:8443$request_uri;
+    }
+  }
+}

--- a/spiffe-support/nginx_fe.conf
+++ b/spiffe-support/nginx_fe.conf
@@ -12,14 +12,14 @@ http {
 
     # Fetch SVIDs
     ssl_spiffe_sock       /tmp/agent.sock;
-    svid_file_path        /certs/fe_svid.pem;
-    svid_key_file_path    /certs/fe_svid_key.pem;
-    svid_bundle_file_path /certs/fe_svid_bundle.pem;
+    svid_file_path        /certs/front_end_svid.pem;
+    svid_key_file_path    /certs/front_end_svid_key.pem;
+    svid_bundle_file_path /certs/front_end_svid_bundle.pem;
 
     proxy_ssl_verify              on;
-    proxy_ssl_certificate         /certs/fe_svid.pem;
-    proxy_ssl_certificate_key     /certs/fe_svid_key.pem;
-    proxy_ssl_trusted_certificate /certs/blog_svid_bundle.pem;
+    proxy_ssl_certificate         /certs/front_end_svid.pem;
+    proxy_ssl_certificate_key     /certs/front_end_svid_key.pem;
+    proxy_ssl_trusted_certificate /certs/front_end_svid_bundle.pem;
 
     proxy_ssl_spiffe on;
     proxy_ssl_spiffe_accept spiffe://example.org/host/blog;

--- a/spiffe-support/src/event/ngx_event_openssl.c
+++ b/spiffe-support/src/event/ngx_event_openssl.c
@@ -714,7 +714,7 @@ ngx_ssl_client_certificate(ngx_conf_t *cf, ngx_ssl_t *ssl, ngx_str_t *cert,
 }
 
 ngx_int_t
-ngx_ssl_spiffe_id_verification(ngx_conf_t *cf, ngx_ssl_t *ssl, ngx_array_t *accepted)
+ngx_ssl_spiffe_id_verification(ngx_ssl_t *ssl, ngx_array_t *accepted)
 {
     int                     n;
     ngx_uint_t              i;
@@ -771,7 +771,7 @@ ngx_ssl_spiffe_id_verification(ngx_conf_t *cf, ngx_ssl_t *ssl, ngx_array_t *acce
     }
 
     ngx_ssl_error(NGX_LOG_EMERG, ssl->log, 0,
-                        "Spiffe id is no accepted \n");
+                        "SPIFFE ID is not accepted: \"%s\"", str->data);
     return NGX_ERROR;    
 }
 
@@ -3289,7 +3289,7 @@ ngx_ssl_check_spiffe_id(ngx_connection_t *c, ngx_array_t *accepted)
     }
 
     ngx_log_debug0(NGX_LOG_DEBUG_EVENT, c->log, 0,
-                        "Spiffe id is no accepted \n");
+                        "SPIFFE ID is not accepted.");
     goto failed;
     
 failed:

--- a/spiffe-support/src/event/ngx_event_openssl.h
+++ b/spiffe-support/src/event/ngx_event_openssl.h
@@ -156,7 +156,7 @@ ngx_int_t ngx_ssl_ciphers(ngx_conf_t *cf, ngx_ssl_t *ssl, ngx_str_t *ciphers,
     ngx_uint_t prefer_server_ciphers);
 ngx_int_t ngx_ssl_client_certificate(ngx_conf_t *cf, ngx_ssl_t *ssl,
     ngx_str_t *cert, ngx_int_t depth);
-ngx_int_t ngx_ssl_spiffe_id_verification(ngx_conf_t *cf, ngx_ssl_t *ssl, 
+ngx_int_t ngx_ssl_spiffe_id_verification(ngx_ssl_t *ssl, 
     ngx_array_t *accepted);
     
 ngx_int_t ngx_ssl_trusted_certificate(ngx_conf_t *cf, ngx_ssl_t *ssl,

--- a/spiffe-support/src/http/modules/ngx_http_ssl_module.c
+++ b/spiffe-support/src/http/modules/ngx_http_ssl_module.c
@@ -762,18 +762,6 @@ ngx_http_ssl_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
         }
     }
 
-    // verify if spiffe sock is enabled
-    //
-    if (conf->ssl_spiffe) {
-        // validate certificate
-        if (ngx_ssl_spiffe_id_verification(cf, &conf->ssl,
-                                       conf->ssl_spiffe_accept)                                       
-            != NGX_OK)
-        {
-            return NGX_CONF_ERROR;
-        }
-    }
-
     if (ngx_ssl_trusted_certificate(cf, &conf->ssl,
                                     &conf->trusted_certificate,
                                     conf->verify_depth)

--- a/spiffe-support/src/http/ngx_http_request.c
+++ b/spiffe-support/src/http/ngx_http_request.c
@@ -1,0 +1,3741 @@
+
+/*
+ * Copyright (C) Igor Sysoev
+ * Copyright (C) Nginx, Inc.
+ */
+
+
+#include <ngx_config.h>
+#include <ngx_core.h>
+#include <ngx_http.h>
+
+
+static void ngx_http_wait_request_handler(ngx_event_t *ev);
+static void ngx_http_process_request_line(ngx_event_t *rev);
+static void ngx_http_process_request_headers(ngx_event_t *rev);
+static ssize_t ngx_http_read_request_header(ngx_http_request_t *r);
+static ngx_int_t ngx_http_alloc_large_header_buffer(ngx_http_request_t *r,
+    ngx_uint_t request_line);
+
+static ngx_int_t ngx_http_process_header_line(ngx_http_request_t *r,
+    ngx_table_elt_t *h, ngx_uint_t offset);
+static ngx_int_t ngx_http_process_unique_header_line(ngx_http_request_t *r,
+    ngx_table_elt_t *h, ngx_uint_t offset);
+static ngx_int_t ngx_http_process_multi_header_lines(ngx_http_request_t *r,
+    ngx_table_elt_t *h, ngx_uint_t offset);
+static ngx_int_t ngx_http_process_host(ngx_http_request_t *r,
+    ngx_table_elt_t *h, ngx_uint_t offset);
+static ngx_int_t ngx_http_process_connection(ngx_http_request_t *r,
+    ngx_table_elt_t *h, ngx_uint_t offset);
+static ngx_int_t ngx_http_process_user_agent(ngx_http_request_t *r,
+    ngx_table_elt_t *h, ngx_uint_t offset);
+
+static ngx_int_t ngx_http_validate_host(ngx_str_t *host, ngx_pool_t *pool,
+    ngx_uint_t alloc);
+static ngx_int_t ngx_http_set_virtual_server(ngx_http_request_t *r,
+    ngx_str_t *host);
+static ngx_int_t ngx_http_find_virtual_server(ngx_connection_t *c,
+    ngx_http_virtual_names_t *virtual_names, ngx_str_t *host,
+    ngx_http_request_t *r, ngx_http_core_srv_conf_t **cscfp);
+
+static void ngx_http_request_handler(ngx_event_t *ev);
+static void ngx_http_terminate_request(ngx_http_request_t *r, ngx_int_t rc);
+static void ngx_http_terminate_handler(ngx_http_request_t *r);
+static void ngx_http_finalize_connection(ngx_http_request_t *r);
+static ngx_int_t ngx_http_set_write_handler(ngx_http_request_t *r);
+static void ngx_http_writer(ngx_http_request_t *r);
+static void ngx_http_request_finalizer(ngx_http_request_t *r);
+
+static void ngx_http_set_keepalive(ngx_http_request_t *r);
+static void ngx_http_keepalive_handler(ngx_event_t *ev);
+static void ngx_http_set_lingering_close(ngx_http_request_t *r);
+static void ngx_http_lingering_close_handler(ngx_event_t *ev);
+static ngx_int_t ngx_http_post_action(ngx_http_request_t *r);
+static void ngx_http_close_request(ngx_http_request_t *r, ngx_int_t error);
+static void ngx_http_log_request(ngx_http_request_t *r);
+
+static u_char *ngx_http_log_error(ngx_log_t *log, u_char *buf, size_t len);
+static u_char *ngx_http_log_error_handler(ngx_http_request_t *r,
+    ngx_http_request_t *sr, u_char *buf, size_t len);
+
+#if (NGX_HTTP_SSL)
+static void ngx_http_ssl_handshake(ngx_event_t *rev);
+static void ngx_http_ssl_handshake_handler(ngx_connection_t *c);
+#endif
+
+
+static char *ngx_http_client_errors[] = {
+
+    /* NGX_HTTP_PARSE_INVALID_METHOD */
+    "client sent invalid method",
+
+    /* NGX_HTTP_PARSE_INVALID_REQUEST */
+    "client sent invalid request",
+
+    /* NGX_HTTP_PARSE_INVALID_VERSION */
+    "client sent invalid version",
+
+    /* NGX_HTTP_PARSE_INVALID_09_METHOD */
+    "client sent invalid method in HTTP/0.9 request"
+};
+
+
+ngx_http_header_t  ngx_http_headers_in[] = {
+    { ngx_string("Host"), offsetof(ngx_http_headers_in_t, host),
+                 ngx_http_process_host },
+
+    { ngx_string("Connection"), offsetof(ngx_http_headers_in_t, connection),
+                 ngx_http_process_connection },
+
+    { ngx_string("If-Modified-Since"),
+                 offsetof(ngx_http_headers_in_t, if_modified_since),
+                 ngx_http_process_unique_header_line },
+
+    { ngx_string("If-Unmodified-Since"),
+                 offsetof(ngx_http_headers_in_t, if_unmodified_since),
+                 ngx_http_process_unique_header_line },
+
+    { ngx_string("If-Match"),
+                 offsetof(ngx_http_headers_in_t, if_match),
+                 ngx_http_process_unique_header_line },
+
+    { ngx_string("If-None-Match"),
+                 offsetof(ngx_http_headers_in_t, if_none_match),
+                 ngx_http_process_unique_header_line },
+
+    { ngx_string("User-Agent"), offsetof(ngx_http_headers_in_t, user_agent),
+                 ngx_http_process_user_agent },
+
+    { ngx_string("Referer"), offsetof(ngx_http_headers_in_t, referer),
+                 ngx_http_process_header_line },
+
+    { ngx_string("Content-Length"),
+                 offsetof(ngx_http_headers_in_t, content_length),
+                 ngx_http_process_unique_header_line },
+
+    { ngx_string("Content-Range"),
+                 offsetof(ngx_http_headers_in_t, content_range),
+                 ngx_http_process_unique_header_line },
+
+    { ngx_string("Content-Type"),
+                 offsetof(ngx_http_headers_in_t, content_type),
+                 ngx_http_process_header_line },
+
+    { ngx_string("Range"), offsetof(ngx_http_headers_in_t, range),
+                 ngx_http_process_header_line },
+
+    { ngx_string("If-Range"),
+                 offsetof(ngx_http_headers_in_t, if_range),
+                 ngx_http_process_unique_header_line },
+
+    { ngx_string("Transfer-Encoding"),
+                 offsetof(ngx_http_headers_in_t, transfer_encoding),
+                 ngx_http_process_header_line },
+
+    { ngx_string("Expect"),
+                 offsetof(ngx_http_headers_in_t, expect),
+                 ngx_http_process_unique_header_line },
+
+    { ngx_string("Upgrade"),
+                 offsetof(ngx_http_headers_in_t, upgrade),
+                 ngx_http_process_header_line },
+
+#if (NGX_HTTP_GZIP || NGX_HTTP_HEADERS)
+    { ngx_string("Accept-Encoding"),
+                 offsetof(ngx_http_headers_in_t, accept_encoding),
+                 ngx_http_process_header_line },
+
+    { ngx_string("Via"), offsetof(ngx_http_headers_in_t, via),
+                 ngx_http_process_header_line },
+#endif
+
+    { ngx_string("Authorization"),
+                 offsetof(ngx_http_headers_in_t, authorization),
+                 ngx_http_process_unique_header_line },
+
+    { ngx_string("Keep-Alive"), offsetof(ngx_http_headers_in_t, keep_alive),
+                 ngx_http_process_header_line },
+
+#if (NGX_HTTP_X_FORWARDED_FOR)
+    { ngx_string("X-Forwarded-For"),
+                 offsetof(ngx_http_headers_in_t, x_forwarded_for),
+                 ngx_http_process_multi_header_lines },
+#endif
+
+#if (NGX_HTTP_REALIP)
+    { ngx_string("X-Real-IP"),
+                 offsetof(ngx_http_headers_in_t, x_real_ip),
+                 ngx_http_process_header_line },
+#endif
+
+#if (NGX_HTTP_HEADERS)
+    { ngx_string("Accept"), offsetof(ngx_http_headers_in_t, accept),
+                 ngx_http_process_header_line },
+
+    { ngx_string("Accept-Language"),
+                 offsetof(ngx_http_headers_in_t, accept_language),
+                 ngx_http_process_header_line },
+#endif
+
+#if (NGX_HTTP_DAV)
+    { ngx_string("Depth"), offsetof(ngx_http_headers_in_t, depth),
+                 ngx_http_process_header_line },
+
+    { ngx_string("Destination"), offsetof(ngx_http_headers_in_t, destination),
+                 ngx_http_process_header_line },
+
+    { ngx_string("Overwrite"), offsetof(ngx_http_headers_in_t, overwrite),
+                 ngx_http_process_header_line },
+
+    { ngx_string("Date"), offsetof(ngx_http_headers_in_t, date),
+                 ngx_http_process_header_line },
+#endif
+
+    { ngx_string("Cookie"), offsetof(ngx_http_headers_in_t, cookies),
+                 ngx_http_process_multi_header_lines },
+
+    { ngx_null_string, 0, NULL }
+};
+
+
+void
+ngx_http_init_connection(ngx_connection_t *c)
+{
+    ngx_uint_t              i;
+    ngx_event_t            *rev;
+    struct sockaddr_in     *sin;
+    ngx_http_port_t        *port;
+    ngx_http_in_addr_t     *addr;
+    ngx_http_log_ctx_t     *ctx;
+    ngx_http_connection_t  *hc;
+#if (NGX_HAVE_INET6)
+    struct sockaddr_in6    *sin6;
+    ngx_http_in6_addr_t    *addr6;
+#endif
+
+    hc = ngx_pcalloc(c->pool, sizeof(ngx_http_connection_t));
+    if (hc == NULL) {
+        ngx_http_close_connection(c);
+        return;
+    }
+
+    c->data = hc;
+
+    /* find the server configuration for the address:port */
+
+    port = c->listening->servers;
+
+    if (port->naddrs > 1) {
+
+        /*
+         * there are several addresses on this port and one of them
+         * is an "*:port" wildcard so getsockname() in ngx_http_server_addr()
+         * is required to determine a server address
+         */
+
+        if (ngx_connection_local_sockaddr(c, NULL, 0) != NGX_OK) {
+            ngx_http_close_connection(c);
+            return;
+        }
+
+        switch (c->local_sockaddr->sa_family) {
+
+#if (NGX_HAVE_INET6)
+        case AF_INET6:
+            sin6 = (struct sockaddr_in6 *) c->local_sockaddr;
+
+            addr6 = port->addrs;
+
+            /* the last address is "*" */
+
+            for (i = 0; i < port->naddrs - 1; i++) {
+                if (ngx_memcmp(&addr6[i].addr6, &sin6->sin6_addr, 16) == 0) {
+                    break;
+                }
+            }
+
+            hc->addr_conf = &addr6[i].conf;
+
+            break;
+#endif
+
+        default: /* AF_INET */
+            sin = (struct sockaddr_in *) c->local_sockaddr;
+
+            addr = port->addrs;
+
+            /* the last address is "*" */
+
+            for (i = 0; i < port->naddrs - 1; i++) {
+                if (addr[i].addr == sin->sin_addr.s_addr) {
+                    break;
+                }
+            }
+
+            hc->addr_conf = &addr[i].conf;
+
+            break;
+        }
+
+    } else {
+
+        switch (c->local_sockaddr->sa_family) {
+
+#if (NGX_HAVE_INET6)
+        case AF_INET6:
+            addr6 = port->addrs;
+            hc->addr_conf = &addr6[0].conf;
+            break;
+#endif
+
+        default: /* AF_INET */
+            addr = port->addrs;
+            hc->addr_conf = &addr[0].conf;
+            break;
+        }
+    }
+
+    /* the default server configuration for the address:port */
+    hc->conf_ctx = hc->addr_conf->default_server->ctx;
+
+    ctx = ngx_palloc(c->pool, sizeof(ngx_http_log_ctx_t));
+    if (ctx == NULL) {
+        ngx_http_close_connection(c);
+        return;
+    }
+
+    ctx->connection = c;
+    ctx->request = NULL;
+    ctx->current_request = NULL;
+
+    c->log->connection = c->number;
+    c->log->handler = ngx_http_log_error;
+    c->log->data = ctx;
+    c->log->action = "waiting for request";
+
+    c->log_error = NGX_ERROR_INFO;
+
+    rev = c->read;
+    rev->handler = ngx_http_wait_request_handler;
+    c->write->handler = ngx_http_empty_handler;
+
+#if (NGX_HTTP_V2)
+    if (hc->addr_conf->http2) {
+        rev->handler = ngx_http_v2_init;
+    }
+#endif
+
+#if (NGX_HTTP_SSL)
+    {
+    ngx_http_ssl_srv_conf_t  *sscf;
+
+    sscf = ngx_http_get_module_srv_conf(hc->conf_ctx, ngx_http_ssl_module);
+
+    if (sscf->enable || hc->addr_conf->ssl) {
+
+        c->log->action = "SSL handshaking";
+
+        if (hc->addr_conf->ssl && sscf->ssl.ctx == NULL) {
+            ngx_log_error(NGX_LOG_ERR, c->log, 0,
+                          "no \"ssl_certificate\" is defined "
+                          "in server listening on SSL port");
+            ngx_http_close_connection(c);
+            return;
+        }
+
+        hc->ssl = 1;
+
+        rev->handler = ngx_http_ssl_handshake;
+    }
+    }
+#endif
+
+    if (hc->addr_conf->proxy_protocol) {
+        hc->proxy_protocol = 1;
+        c->log->action = "reading PROXY protocol";
+    }
+
+    if (rev->ready) {
+        /* the deferred accept(), iocp */
+
+        if (ngx_use_accept_mutex) {
+            ngx_post_event(rev, &ngx_posted_events);
+            return;
+        }
+
+        rev->handler(rev);
+        return;
+    }
+
+    ngx_add_timer(rev, c->listening->post_accept_timeout);
+    ngx_reusable_connection(c, 1);
+
+    if (ngx_handle_read_event(rev, 0) != NGX_OK) {
+        ngx_http_close_connection(c);
+        return;
+    }
+}
+
+
+static void
+ngx_http_wait_request_handler(ngx_event_t *rev)
+{
+    u_char                    *p;
+    size_t                     size;
+    ssize_t                    n;
+    ngx_buf_t                 *b;
+    ngx_connection_t          *c;
+    ngx_http_connection_t     *hc;
+    ngx_http_core_srv_conf_t  *cscf;
+
+    c = rev->data;
+
+    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, c->log, 0, "http wait request handler");
+
+    if (rev->timedout) {
+        ngx_log_error(NGX_LOG_INFO, c->log, NGX_ETIMEDOUT, "client timed out");
+        ngx_http_close_connection(c);
+        return;
+    }
+
+    if (c->close) {
+        ngx_http_close_connection(c);
+        return;
+    }
+
+    hc = c->data;
+    cscf = ngx_http_get_module_srv_conf(hc->conf_ctx, ngx_http_core_module);
+
+    size = cscf->client_header_buffer_size;
+
+    b = c->buffer;
+
+    if (b == NULL) {
+        b = ngx_create_temp_buf(c->pool, size);
+        if (b == NULL) {
+            ngx_http_close_connection(c);
+            return;
+        }
+
+        c->buffer = b;
+
+    } else if (b->start == NULL) {
+
+        b->start = ngx_palloc(c->pool, size);
+        if (b->start == NULL) {
+            ngx_http_close_connection(c);
+            return;
+        }
+
+        b->pos = b->start;
+        b->last = b->start;
+        b->end = b->last + size;
+    }
+
+    n = c->recv(c, b->last, size);
+
+    if (n == NGX_AGAIN) {
+
+        if (!rev->timer_set) {
+            ngx_add_timer(rev, c->listening->post_accept_timeout);
+            ngx_reusable_connection(c, 1);
+        }
+
+        if (ngx_handle_read_event(rev, 0) != NGX_OK) {
+            ngx_http_close_connection(c);
+            return;
+        }
+
+        /*
+         * We are trying to not hold c->buffer's memory for an idle connection.
+         */
+
+        if (ngx_pfree(c->pool, b->start) == NGX_OK) {
+            b->start = NULL;
+        }
+
+        return;
+    }
+
+    if (n == NGX_ERROR) {
+        ngx_http_close_connection(c);
+        return;
+    }
+
+    if (n == 0) {
+        ngx_log_error(NGX_LOG_INFO, c->log, 0,
+                      "client closed connection");
+        ngx_http_close_connection(c);
+        return;
+    }
+
+    b->last += n;
+
+    if (hc->proxy_protocol) {
+        hc->proxy_protocol = 0;
+
+        p = ngx_proxy_protocol_read(c, b->pos, b->last);
+
+        if (p == NULL) {
+            ngx_http_close_connection(c);
+            return;
+        }
+
+        b->pos = p;
+
+        if (b->pos == b->last) {
+            c->log->action = "waiting for request";
+            b->pos = b->start;
+            b->last = b->start;
+            ngx_post_event(rev, &ngx_posted_events);
+            return;
+        }
+    }
+
+    c->log->action = "reading client request line";
+
+    ngx_reusable_connection(c, 0);
+
+    c->data = ngx_http_create_request(c);
+    if (c->data == NULL) {
+        ngx_http_close_connection(c);
+        return;
+    }
+
+    rev->handler = ngx_http_process_request_line;
+    ngx_http_process_request_line(rev);
+}
+
+
+ngx_http_request_t *
+ngx_http_create_request(ngx_connection_t *c)
+{
+    ngx_pool_t                 *pool;
+    ngx_time_t                 *tp;
+    ngx_http_request_t         *r;
+    ngx_http_log_ctx_t         *ctx;
+    ngx_http_connection_t      *hc;
+    ngx_http_core_srv_conf_t   *cscf;
+    ngx_http_core_loc_conf_t   *clcf;
+    ngx_http_core_main_conf_t  *cmcf;
+
+    c->requests++;
+
+    hc = c->data;
+
+    cscf = ngx_http_get_module_srv_conf(hc->conf_ctx, ngx_http_core_module);
+
+    pool = ngx_create_pool(cscf->request_pool_size, c->log);
+    if (pool == NULL) {
+        return NULL;
+    }
+
+    r = ngx_pcalloc(pool, sizeof(ngx_http_request_t));
+    if (r == NULL) {
+        ngx_destroy_pool(pool);
+        return NULL;
+    }
+
+    r->pool = pool;
+
+    r->http_connection = hc;
+    r->signature = NGX_HTTP_MODULE;
+    r->connection = c;
+
+    r->main_conf = hc->conf_ctx->main_conf;
+    r->srv_conf = hc->conf_ctx->srv_conf;
+    r->loc_conf = hc->conf_ctx->loc_conf;
+
+    r->read_event_handler = ngx_http_block_reading;
+
+    clcf = ngx_http_get_module_loc_conf(r, ngx_http_core_module);
+
+    ngx_set_connection_log(r->connection, clcf->error_log);
+
+    r->header_in = hc->busy ? hc->busy->buf : c->buffer;
+
+    if (ngx_list_init(&r->headers_out.headers, r->pool, 20,
+                      sizeof(ngx_table_elt_t))
+        != NGX_OK)
+    {
+        ngx_destroy_pool(r->pool);
+        return NULL;
+    }
+
+    if (ngx_list_init(&r->headers_out.trailers, r->pool, 4,
+                      sizeof(ngx_table_elt_t))
+        != NGX_OK)
+    {
+        ngx_destroy_pool(r->pool);
+        return NULL;
+    }
+
+    r->ctx = ngx_pcalloc(r->pool, sizeof(void *) * ngx_http_max_module);
+    if (r->ctx == NULL) {
+        ngx_destroy_pool(r->pool);
+        return NULL;
+    }
+
+    cmcf = ngx_http_get_module_main_conf(r, ngx_http_core_module);
+
+    r->variables = ngx_pcalloc(r->pool, cmcf->variables.nelts
+                                        * sizeof(ngx_http_variable_value_t));
+    if (r->variables == NULL) {
+        ngx_destroy_pool(r->pool);
+        return NULL;
+    }
+
+#if (NGX_HTTP_SSL)
+    if (c->ssl) {
+        r->main_filter_need_in_memory = 1;
+    }
+#endif
+
+    r->main = r;
+    r->count = 1;
+
+    tp = ngx_timeofday();
+    r->start_sec = tp->sec;
+    r->start_msec = tp->msec;
+
+    r->method = NGX_HTTP_UNKNOWN;
+    r->http_version = NGX_HTTP_VERSION_10;
+
+    r->headers_in.content_length_n = -1;
+    r->headers_in.keep_alive_n = -1;
+    r->headers_out.content_length_n = -1;
+    r->headers_out.last_modified_time = -1;
+
+    r->uri_changes = NGX_HTTP_MAX_URI_CHANGES + 1;
+    r->subrequests = NGX_HTTP_MAX_SUBREQUESTS + 1;
+
+    r->http_state = NGX_HTTP_READING_REQUEST_STATE;
+
+    ctx = c->log->data;
+    ctx->request = r;
+    ctx->current_request = r;
+    r->log_handler = ngx_http_log_error_handler;
+
+#if (NGX_STAT_STUB)
+    (void) ngx_atomic_fetch_add(ngx_stat_reading, 1);
+    r->stat_reading = 1;
+    (void) ngx_atomic_fetch_add(ngx_stat_requests, 1);
+#endif
+
+    return r;
+}
+
+
+#if (NGX_HTTP_SSL)
+
+static void
+ngx_http_ssl_handshake(ngx_event_t *rev)
+{
+    u_char                    *p, buf[NGX_PROXY_PROTOCOL_MAX_HEADER + 1];
+    size_t                     size;
+    ssize_t                    n;
+    ngx_err_t                  err;
+    ngx_int_t                  rc;
+    ngx_connection_t          *c;
+    ngx_http_connection_t     *hc;
+    ngx_http_ssl_srv_conf_t   *sscf;
+    ngx_http_core_loc_conf_t  *clcf;
+
+    c = rev->data;
+    hc = c->data;
+
+    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, rev->log, 0,
+                   "http check ssl handshake");
+
+    if (rev->timedout) {
+        ngx_log_error(NGX_LOG_INFO, c->log, NGX_ETIMEDOUT, "client timed out");
+        ngx_http_close_connection(c);
+        return;
+    }
+
+    if (c->close) {
+        ngx_http_close_connection(c);
+        return;
+    }
+
+    size = hc->proxy_protocol ? sizeof(buf) : 1;
+
+    n = recv(c->fd, (char *) buf, size, MSG_PEEK);
+
+    err = ngx_socket_errno;
+
+    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, rev->log, 0, "http recv(): %z", n);
+
+    if (n == -1) {
+        if (err == NGX_EAGAIN) {
+            rev->ready = 0;
+
+            if (!rev->timer_set) {
+                ngx_add_timer(rev, c->listening->post_accept_timeout);
+                ngx_reusable_connection(c, 1);
+            }
+
+            if (ngx_handle_read_event(rev, 0) != NGX_OK) {
+                ngx_http_close_connection(c);
+            }
+
+            return;
+        }
+
+        ngx_connection_error(c, err, "recv() failed");
+        ngx_http_close_connection(c);
+
+        return;
+    }
+
+    if (hc->proxy_protocol) {
+        hc->proxy_protocol = 0;
+
+        p = ngx_proxy_protocol_read(c, buf, buf + n);
+
+        if (p == NULL) {
+            ngx_http_close_connection(c);
+            return;
+        }
+
+        size = p - buf;
+
+        if (c->recv(c, buf, size) != (ssize_t) size) {
+            ngx_http_close_connection(c);
+            return;
+        }
+
+        c->log->action = "SSL handshaking";
+
+        if (n == (ssize_t) size) {
+            ngx_post_event(rev, &ngx_posted_events);
+            return;
+        }
+
+        n = 1;
+        buf[0] = *p;
+    }
+
+    if (n == 1) {
+        if (buf[0] & 0x80 /* SSLv2 */ || buf[0] == 0x16 /* SSLv3/TLSv1 */) {
+            ngx_log_debug1(NGX_LOG_DEBUG_HTTP, rev->log, 0,
+                           "https ssl handshake: 0x%02Xd", buf[0]);
+
+            clcf = ngx_http_get_module_loc_conf(hc->conf_ctx,
+                                                ngx_http_core_module);
+
+            if (clcf->tcp_nodelay && ngx_tcp_nodelay(c) != NGX_OK) {
+                ngx_http_close_connection(c);
+                return;
+            }
+
+            sscf = ngx_http_get_module_srv_conf(hc->conf_ctx,
+                                                ngx_http_ssl_module);
+
+            if (ngx_ssl_create_connection(&sscf->ssl, c, NGX_SSL_BUFFER)
+                != NGX_OK)
+            {
+                ngx_http_close_connection(c);
+                return;
+            }
+
+            rc = ngx_ssl_handshake(c);
+
+            if (rc == NGX_AGAIN) {
+
+                if (!rev->timer_set) {
+                    ngx_add_timer(rev, c->listening->post_accept_timeout);
+                }
+
+                ngx_reusable_connection(c, 0);
+
+                c->ssl->handler = ngx_http_ssl_handshake_handler;
+                return;
+            }
+
+            ngx_http_ssl_handshake_handler(c);
+
+            return;
+        }
+
+        ngx_log_debug0(NGX_LOG_DEBUG_HTTP, rev->log, 0, "plain http");
+
+        c->log->action = "waiting for request";
+
+        rev->handler = ngx_http_wait_request_handler;
+        ngx_http_wait_request_handler(rev);
+
+        return;
+    }
+
+    ngx_log_error(NGX_LOG_INFO, c->log, 0, "client closed connection");
+    ngx_http_close_connection(c);
+}
+
+
+static void
+ngx_http_ssl_handshake_handler(ngx_connection_t *c)
+{
+    if (c->ssl->handshaked) {
+
+        /*
+         * The majority of browsers do not send the "close notify" alert.
+         * Among them are MSIE, old Mozilla, Netscape 4, Konqueror,
+         * and Links.  And what is more, MSIE ignores the server's alert.
+         *
+         * Opera and recent Mozilla send the alert.
+         */
+
+        c->ssl->no_wait_shutdown = 1;
+
+#if (NGX_HTTP_V2                                                              \
+     && (defined TLSEXT_TYPE_application_layer_protocol_negotiation           \
+         || defined TLSEXT_TYPE_next_proto_neg))
+        {
+        unsigned int            len;
+        const unsigned char    *data;
+        ngx_http_connection_t  *hc;
+
+        hc = c->data;
+
+        if (hc->addr_conf->http2) {
+
+#ifdef TLSEXT_TYPE_application_layer_protocol_negotiation
+            SSL_get0_alpn_selected(c->ssl->connection, &data, &len);
+
+#ifdef TLSEXT_TYPE_next_proto_neg
+            if (len == 0) {
+                SSL_get0_next_proto_negotiated(c->ssl->connection, &data, &len);
+            }
+#endif
+
+#else /* TLSEXT_TYPE_next_proto_neg */
+            SSL_get0_next_proto_negotiated(c->ssl->connection, &data, &len);
+#endif
+
+            if (len == 2 && data[0] == 'h' && data[1] == '2') {
+                ngx_http_v2_init(c->read);
+                return;
+            }
+        }
+        }
+#endif
+
+        c->log->action = "waiting for request";
+
+        c->read->handler = ngx_http_wait_request_handler;
+        /* STUB: epoll edge */ c->write->handler = ngx_http_empty_handler;
+
+        ngx_reusable_connection(c, 1);
+
+        ngx_http_wait_request_handler(c->read);
+
+        return;
+    }
+
+    if (c->read->timedout) {
+        ngx_log_error(NGX_LOG_INFO, c->log, NGX_ETIMEDOUT, "client timed out");
+    }
+
+    ngx_http_close_connection(c);
+}
+
+#ifdef SSL_CTRL_SET_TLSEXT_HOSTNAME
+
+int
+ngx_http_ssl_servername(ngx_ssl_conn_t *ssl_conn, int *ad, void *arg)
+{
+    ngx_str_t                  host;
+    const char                *servername;
+    ngx_connection_t          *c;
+    ngx_http_connection_t     *hc;
+    ngx_http_ssl_srv_conf_t   *sscf;
+    ngx_http_core_loc_conf_t  *clcf;
+    ngx_http_core_srv_conf_t  *cscf;
+
+    servername = SSL_get_servername(ssl_conn, TLSEXT_NAMETYPE_host_name);
+
+    if (servername == NULL) {
+        return SSL_TLSEXT_ERR_NOACK;
+    }
+
+    c = ngx_ssl_get_connection(ssl_conn);
+    
+    if (c->ssl->renegotiation) {
+        return SSL_TLSEXT_ERR_NOACK;
+    }
+
+    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, c->log, 0,
+                   "SSL server name: \"%s\"", servername);
+
+    host.len = ngx_strlen(servername);
+
+    if (host.len == 0) {
+        return SSL_TLSEXT_ERR_NOACK;
+    }
+
+    host.data = (u_char *) servername;
+
+    if (ngx_http_validate_host(&host, c->pool, 1) != NGX_OK) {
+        return SSL_TLSEXT_ERR_NOACK;
+    }
+
+    hc = c->data;
+
+    if (ngx_http_find_virtual_server(c, hc->addr_conf->virtual_names, &host,
+                                     NULL, &cscf)
+        != NGX_OK)
+    {
+        return SSL_TLSEXT_ERR_NOACK;
+    }
+
+    hc->ssl_servername = ngx_palloc(c->pool, sizeof(ngx_str_t));
+    if (hc->ssl_servername == NULL) {
+        return SSL_TLSEXT_ERR_NOACK;
+    }
+
+    *hc->ssl_servername = host;
+
+    hc->conf_ctx = cscf->ctx;
+
+    clcf = ngx_http_get_module_loc_conf(hc->conf_ctx, ngx_http_core_module);
+
+    ngx_set_connection_log(c, clcf->error_log);
+
+    sscf = ngx_http_get_module_srv_conf(hc->conf_ctx, ngx_http_ssl_module);
+
+    c->ssl->buffer_size = sscf->buffer_size;
+
+    if (sscf->ssl.ctx) {
+        SSL_set_SSL_CTX(ssl_conn, sscf->ssl.ctx);
+
+        /*
+         * SSL_set_SSL_CTX() only changes certs as of 1.0.0d
+         * adjust other things we care about
+         */
+
+        SSL_set_verify(ssl_conn, SSL_CTX_get_verify_mode(sscf->ssl.ctx),
+                       SSL_CTX_get_verify_callback(sscf->ssl.ctx));
+
+        SSL_set_verify_depth(ssl_conn, SSL_CTX_get_verify_depth(sscf->ssl.ctx));
+
+#ifdef SSL_CTRL_CLEAR_OPTIONS
+        /* only in 0.9.8m+ */
+        SSL_clear_options(ssl_conn, SSL_get_options(ssl_conn) &
+                                    ~SSL_CTX_get_options(sscf->ssl.ctx));
+#endif
+
+        SSL_set_options(ssl_conn, SSL_CTX_get_options(sscf->ssl.ctx));
+    }
+
+    return SSL_TLSEXT_ERR_OK;
+}
+
+#endif
+
+#endif
+
+
+static void
+ngx_http_process_request_line(ngx_event_t *rev)
+{
+    ssize_t              n;
+    ngx_int_t            rc, rv;
+    ngx_str_t            host;
+    ngx_connection_t    *c;
+    ngx_http_request_t  *r;
+
+    c = rev->data;
+    r = c->data;
+
+    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, rev->log, 0,
+                   "http process request line");
+
+    if (rev->timedout) {
+        ngx_log_error(NGX_LOG_INFO, c->log, NGX_ETIMEDOUT, "client timed out");
+        c->timedout = 1;
+        ngx_http_close_request(r, NGX_HTTP_REQUEST_TIME_OUT);
+        return;
+    }
+
+    rc = NGX_AGAIN;
+
+    for ( ;; ) {
+
+        if (rc == NGX_AGAIN) {
+            n = ngx_http_read_request_header(r);
+
+            if (n == NGX_AGAIN || n == NGX_ERROR) {
+                return;
+            }
+        }
+
+        rc = ngx_http_parse_request_line(r, r->header_in);
+
+        if (rc == NGX_OK) {
+
+            /* the request line has been parsed successfully */
+
+            r->request_line.len = r->request_end - r->request_start;
+            r->request_line.data = r->request_start;
+            r->request_length = r->header_in->pos - r->request_start;
+
+            ngx_log_debug1(NGX_LOG_DEBUG_HTTP, c->log, 0,
+                           "http request line: \"%V\"", &r->request_line);
+
+            r->method_name.len = r->method_end - r->request_start + 1;
+            r->method_name.data = r->request_line.data;
+
+            if (r->http_protocol.data) {
+                r->http_protocol.len = r->request_end - r->http_protocol.data;
+            }
+
+            if (ngx_http_process_request_uri(r) != NGX_OK) {
+                return;
+            }
+
+            if (r->host_start && r->host_end) {
+
+                host.len = r->host_end - r->host_start;
+                host.data = r->host_start;
+
+                rc = ngx_http_validate_host(&host, r->pool, 0);
+
+                if (rc == NGX_DECLINED) {
+                    ngx_log_error(NGX_LOG_INFO, c->log, 0,
+                                  "client sent invalid host in request line");
+                    ngx_http_finalize_request(r, NGX_HTTP_BAD_REQUEST);
+                    return;
+                }
+
+                if (rc == NGX_ERROR) {
+                    ngx_http_close_request(r, NGX_HTTP_INTERNAL_SERVER_ERROR);
+                    return;
+                }
+
+                if (ngx_http_set_virtual_server(r, &host) == NGX_ERROR) {
+                    return;
+                }
+
+                r->headers_in.server = host;
+            }
+
+            if (r->http_version < NGX_HTTP_VERSION_10) {
+
+                if (r->headers_in.server.len == 0
+                    && ngx_http_set_virtual_server(r, &r->headers_in.server)
+                       == NGX_ERROR)
+                {
+                    return;
+                }
+
+                ngx_http_process_request(r);
+                return;
+            }
+
+
+            if (ngx_list_init(&r->headers_in.headers, r->pool, 20,
+                              sizeof(ngx_table_elt_t))
+                != NGX_OK)
+            {
+                ngx_http_close_request(r, NGX_HTTP_INTERNAL_SERVER_ERROR);
+                return;
+            }
+
+            c->log->action = "reading client request headers";
+
+            rev->handler = ngx_http_process_request_headers;
+            ngx_http_process_request_headers(rev);
+
+            return;
+        }
+
+        if (rc != NGX_AGAIN) {
+
+            /* there was error while a request line parsing */
+
+            ngx_log_error(NGX_LOG_INFO, c->log, 0,
+                          ngx_http_client_errors[rc - NGX_HTTP_CLIENT_ERROR]);
+
+            if (rc == NGX_HTTP_PARSE_INVALID_VERSION) {
+                ngx_http_finalize_request(r, NGX_HTTP_VERSION_NOT_SUPPORTED);
+
+            } else {
+                ngx_http_finalize_request(r, NGX_HTTP_BAD_REQUEST);
+            }
+
+            return;
+        }
+
+        /* NGX_AGAIN: a request line parsing is still incomplete */
+
+        if (r->header_in->pos == r->header_in->end) {
+
+            rv = ngx_http_alloc_large_header_buffer(r, 1);
+
+            if (rv == NGX_ERROR) {
+                ngx_http_close_request(r, NGX_HTTP_INTERNAL_SERVER_ERROR);
+                return;
+            }
+
+            if (rv == NGX_DECLINED) {
+                r->request_line.len = r->header_in->end - r->request_start;
+                r->request_line.data = r->request_start;
+
+                ngx_log_error(NGX_LOG_INFO, c->log, 0,
+                              "client sent too long URI");
+                ngx_http_finalize_request(r, NGX_HTTP_REQUEST_URI_TOO_LARGE);
+                return;
+            }
+        }
+    }
+}
+
+
+ngx_int_t
+ngx_http_process_request_uri(ngx_http_request_t *r)
+{
+    ngx_http_core_srv_conf_t  *cscf;
+
+    if (r->args_start) {
+        r->uri.len = r->args_start - 1 - r->uri_start;
+    } else {
+        r->uri.len = r->uri_end - r->uri_start;
+    }
+
+    if (r->complex_uri || r->quoted_uri) {
+
+        r->uri.data = ngx_pnalloc(r->pool, r->uri.len + 1);
+        if (r->uri.data == NULL) {
+            ngx_http_close_request(r, NGX_HTTP_INTERNAL_SERVER_ERROR);
+            return NGX_ERROR;
+        }
+
+        cscf = ngx_http_get_module_srv_conf(r, ngx_http_core_module);
+
+        if (ngx_http_parse_complex_uri(r, cscf->merge_slashes) != NGX_OK) {
+            r->uri.len = 0;
+
+            ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,
+                          "client sent invalid request");
+            ngx_http_finalize_request(r, NGX_HTTP_BAD_REQUEST);
+            return NGX_ERROR;
+        }
+
+    } else {
+        r->uri.data = r->uri_start;
+    }
+
+    r->unparsed_uri.len = r->uri_end - r->uri_start;
+    r->unparsed_uri.data = r->uri_start;
+
+    r->valid_unparsed_uri = r->space_in_uri ? 0 : 1;
+
+    if (r->uri_ext) {
+        if (r->args_start) {
+            r->exten.len = r->args_start - 1 - r->uri_ext;
+        } else {
+            r->exten.len = r->uri_end - r->uri_ext;
+        }
+
+        r->exten.data = r->uri_ext;
+    }
+
+    if (r->args_start && r->uri_end > r->args_start) {
+        r->args.len = r->uri_end - r->args_start;
+        r->args.data = r->args_start;
+    }
+
+#if (NGX_WIN32)
+    {
+    u_char  *p, *last;
+
+    p = r->uri.data;
+    last = r->uri.data + r->uri.len;
+
+    while (p < last) {
+
+        if (*p++ == ':') {
+
+            /*
+             * this check covers "::$data", "::$index_allocation" and
+             * ":$i30:$index_allocation"
+             */
+
+            if (p < last && *p == '$') {
+                ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,
+                              "client sent unsafe win32 URI");
+                ngx_http_finalize_request(r, NGX_HTTP_BAD_REQUEST);
+                return NGX_ERROR;
+            }
+        }
+    }
+
+    p = r->uri.data + r->uri.len - 1;
+
+    while (p > r->uri.data) {
+
+        if (*p == ' ') {
+            p--;
+            continue;
+        }
+
+        if (*p == '.') {
+            p--;
+            continue;
+        }
+
+        break;
+    }
+
+    if (p != r->uri.data + r->uri.len - 1) {
+        r->uri.len = p + 1 - r->uri.data;
+        ngx_http_set_exten(r);
+    }
+
+    }
+#endif
+
+    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                   "http uri: \"%V\"", &r->uri);
+
+    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                   "http args: \"%V\"", &r->args);
+
+    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                   "http exten: \"%V\"", &r->exten);
+
+    return NGX_OK;
+}
+
+
+static void
+ngx_http_process_request_headers(ngx_event_t *rev)
+{
+    u_char                     *p;
+    size_t                      len;
+    ssize_t                     n;
+    ngx_int_t                   rc, rv;
+    ngx_table_elt_t            *h;
+    ngx_connection_t           *c;
+    ngx_http_header_t          *hh;
+    ngx_http_request_t         *r;
+    ngx_http_core_srv_conf_t   *cscf;
+    ngx_http_core_main_conf_t  *cmcf;
+
+    c = rev->data;
+    r = c->data;
+
+    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, rev->log, 0,
+                   "http process request header line");
+
+    if (rev->timedout) {
+        ngx_log_error(NGX_LOG_INFO, c->log, NGX_ETIMEDOUT, "client timed out");
+        c->timedout = 1;
+        ngx_http_close_request(r, NGX_HTTP_REQUEST_TIME_OUT);
+        return;
+    }
+
+    cmcf = ngx_http_get_module_main_conf(r, ngx_http_core_module);
+
+    rc = NGX_AGAIN;
+
+    for ( ;; ) {
+
+        if (rc == NGX_AGAIN) {
+
+            if (r->header_in->pos == r->header_in->end) {
+
+                rv = ngx_http_alloc_large_header_buffer(r, 0);
+
+                if (rv == NGX_ERROR) {
+                    ngx_http_close_request(r, NGX_HTTP_INTERNAL_SERVER_ERROR);
+                    return;
+                }
+
+                if (rv == NGX_DECLINED) {
+                    p = r->header_name_start;
+
+                    r->lingering_close = 1;
+
+                    if (p == NULL) {
+                        ngx_log_error(NGX_LOG_INFO, c->log, 0,
+                                      "client sent too large request");
+                        ngx_http_finalize_request(r,
+                                            NGX_HTTP_REQUEST_HEADER_TOO_LARGE);
+                        return;
+                    }
+
+                    len = r->header_in->end - p;
+
+                    if (len > NGX_MAX_ERROR_STR - 300) {
+                        len = NGX_MAX_ERROR_STR - 300;
+                    }
+
+                    ngx_log_error(NGX_LOG_INFO, c->log, 0,
+                                "client sent too long header line: \"%*s...\"",
+                                len, r->header_name_start);
+
+                    ngx_http_finalize_request(r,
+                                            NGX_HTTP_REQUEST_HEADER_TOO_LARGE);
+                    return;
+                }
+            }
+
+            n = ngx_http_read_request_header(r);
+
+            if (n == NGX_AGAIN || n == NGX_ERROR) {
+                return;
+            }
+        }
+
+        /* the host header could change the server configuration context */
+        cscf = ngx_http_get_module_srv_conf(r, ngx_http_core_module);
+
+        rc = ngx_http_parse_header_line(r, r->header_in,
+                                        cscf->underscores_in_headers);
+
+        if (rc == NGX_OK) {
+
+            r->request_length += r->header_in->pos - r->header_name_start;
+
+            if (r->invalid_header && cscf->ignore_invalid_headers) {
+
+                /* there was error while a header line parsing */
+
+                ngx_log_error(NGX_LOG_INFO, c->log, 0,
+                              "client sent invalid header line: \"%*s\"",
+                              r->header_end - r->header_name_start,
+                              r->header_name_start);
+                continue;
+            }
+
+            /* a header line has been parsed successfully */
+
+            h = ngx_list_push(&r->headers_in.headers);
+            if (h == NULL) {
+                ngx_http_close_request(r, NGX_HTTP_INTERNAL_SERVER_ERROR);
+                return;
+            }
+
+            h->hash = r->header_hash;
+
+            h->key.len = r->header_name_end - r->header_name_start;
+            h->key.data = r->header_name_start;
+            h->key.data[h->key.len] = '\0';
+
+            h->value.len = r->header_end - r->header_start;
+            h->value.data = r->header_start;
+            h->value.data[h->value.len] = '\0';
+
+            h->lowcase_key = ngx_pnalloc(r->pool, h->key.len);
+            if (h->lowcase_key == NULL) {
+                ngx_http_close_request(r, NGX_HTTP_INTERNAL_SERVER_ERROR);
+                return;
+            }
+
+            if (h->key.len == r->lowcase_index) {
+                ngx_memcpy(h->lowcase_key, r->lowcase_header, h->key.len);
+
+            } else {
+                ngx_strlow(h->lowcase_key, h->key.data, h->key.len);
+            }
+
+            hh = ngx_hash_find(&cmcf->headers_in_hash, h->hash,
+                               h->lowcase_key, h->key.len);
+
+            if (hh && hh->handler(r, h, hh->offset) != NGX_OK) {
+                return;
+            }
+
+            ngx_log_debug2(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                           "http header: \"%V: %V\"",
+                           &h->key, &h->value);
+
+            continue;
+        }
+
+        if (rc == NGX_HTTP_PARSE_HEADER_DONE) {
+
+            /* a whole header has been parsed successfully */
+
+            ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                           "http header done");
+
+            r->request_length += r->header_in->pos - r->header_name_start;
+
+            r->http_state = NGX_HTTP_PROCESS_REQUEST_STATE;
+
+            rc = ngx_http_process_request_header(r);
+
+            if (rc != NGX_OK) {
+                return;
+            }
+
+            ngx_http_process_request(r);
+
+            return;
+        }
+
+        if (rc == NGX_AGAIN) {
+
+            /* a header line parsing is still not complete */
+
+            continue;
+        }
+
+        /* rc == NGX_HTTP_PARSE_INVALID_HEADER */
+
+        ngx_log_error(NGX_LOG_INFO, c->log, 0,
+                      "client sent invalid header line");
+
+        ngx_http_finalize_request(r, NGX_HTTP_BAD_REQUEST);
+        return;
+    }
+}
+
+
+static ssize_t
+ngx_http_read_request_header(ngx_http_request_t *r)
+{
+    ssize_t                    n;
+    ngx_event_t               *rev;
+    ngx_connection_t          *c;
+    ngx_http_core_srv_conf_t  *cscf;
+
+    c = r->connection;
+    rev = c->read;
+
+    n = r->header_in->last - r->header_in->pos;
+
+    if (n > 0) {
+        return n;
+    }
+
+    if (rev->ready) {
+        n = c->recv(c, r->header_in->last,
+                    r->header_in->end - r->header_in->last);
+    } else {
+        n = NGX_AGAIN;
+    }
+
+    if (n == NGX_AGAIN) {
+        if (!rev->timer_set) {
+            cscf = ngx_http_get_module_srv_conf(r, ngx_http_core_module);
+            ngx_add_timer(rev, cscf->client_header_timeout);
+        }
+
+        if (ngx_handle_read_event(rev, 0) != NGX_OK) {
+            ngx_http_close_request(r, NGX_HTTP_INTERNAL_SERVER_ERROR);
+            return NGX_ERROR;
+        }
+
+        return NGX_AGAIN;
+    }
+
+    if (n == 0) {
+        ngx_log_error(NGX_LOG_INFO, c->log, 0,
+                      "client prematurely closed connection");
+    }
+
+    if (n == 0 || n == NGX_ERROR) {
+        c->error = 1;
+        c->log->action = "reading client request headers";
+
+        ngx_http_finalize_request(r, NGX_HTTP_BAD_REQUEST);
+        return NGX_ERROR;
+    }
+
+    r->header_in->last += n;
+
+    return n;
+}
+
+
+static ngx_int_t
+ngx_http_alloc_large_header_buffer(ngx_http_request_t *r,
+    ngx_uint_t request_line)
+{
+    u_char                    *old, *new;
+    ngx_buf_t                 *b;
+    ngx_chain_t               *cl;
+    ngx_http_connection_t     *hc;
+    ngx_http_core_srv_conf_t  *cscf;
+
+    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                   "http alloc large header buffer");
+
+    if (request_line && r->state == 0) {
+
+        /* the client fills up the buffer with "\r\n" */
+
+        r->header_in->pos = r->header_in->start;
+        r->header_in->last = r->header_in->start;
+
+        return NGX_OK;
+    }
+
+    old = request_line ? r->request_start : r->header_name_start;
+
+    cscf = ngx_http_get_module_srv_conf(r, ngx_http_core_module);
+
+    if (r->state != 0
+        && (size_t) (r->header_in->pos - old)
+                                     >= cscf->large_client_header_buffers.size)
+    {
+        return NGX_DECLINED;
+    }
+
+    hc = r->http_connection;
+
+    if (hc->free) {
+        cl = hc->free;
+        hc->free = cl->next;
+
+        b = cl->buf;
+
+        ngx_log_debug2(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                       "http large header free: %p %uz",
+                       b->pos, b->end - b->last);
+
+    } else if (hc->nbusy < cscf->large_client_header_buffers.num) {
+
+        b = ngx_create_temp_buf(r->connection->pool,
+                                cscf->large_client_header_buffers.size);
+        if (b == NULL) {
+            return NGX_ERROR;
+        }
+
+        cl = ngx_alloc_chain_link(r->connection->pool);
+        if (cl == NULL) {
+            return NGX_ERROR;
+        }
+
+        cl->buf = b;
+
+        ngx_log_debug2(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                       "http large header alloc: %p %uz",
+                       b->pos, b->end - b->last);
+
+    } else {
+        return NGX_DECLINED;
+    }
+
+    cl->next = hc->busy;
+    hc->busy = cl;
+    hc->nbusy++;
+
+    if (r->state == 0) {
+        /*
+         * r->state == 0 means that a header line was parsed successfully
+         * and we do not need to copy incomplete header line and
+         * to relocate the parser header pointers
+         */
+
+        r->header_in = b;
+
+        return NGX_OK;
+    }
+
+    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                   "http large header copy: %uz", r->header_in->pos - old);
+
+    new = b->start;
+
+    ngx_memcpy(new, old, r->header_in->pos - old);
+
+    b->pos = new + (r->header_in->pos - old);
+    b->last = new + (r->header_in->pos - old);
+
+    if (request_line) {
+        r->request_start = new;
+
+        if (r->request_end) {
+            r->request_end = new + (r->request_end - old);
+        }
+
+        r->method_end = new + (r->method_end - old);
+
+        r->uri_start = new + (r->uri_start - old);
+        r->uri_end = new + (r->uri_end - old);
+
+        if (r->schema_start) {
+            r->schema_start = new + (r->schema_start - old);
+            r->schema_end = new + (r->schema_end - old);
+        }
+
+        if (r->host_start) {
+            r->host_start = new + (r->host_start - old);
+            if (r->host_end) {
+                r->host_end = new + (r->host_end - old);
+            }
+        }
+
+        if (r->port_start) {
+            r->port_start = new + (r->port_start - old);
+            r->port_end = new + (r->port_end - old);
+        }
+
+        if (r->uri_ext) {
+            r->uri_ext = new + (r->uri_ext - old);
+        }
+
+        if (r->args_start) {
+            r->args_start = new + (r->args_start - old);
+        }
+
+        if (r->http_protocol.data) {
+            r->http_protocol.data = new + (r->http_protocol.data - old);
+        }
+
+    } else {
+        r->header_name_start = new;
+        r->header_name_end = new + (r->header_name_end - old);
+        r->header_start = new + (r->header_start - old);
+        r->header_end = new + (r->header_end - old);
+    }
+
+    r->header_in = b;
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_http_process_header_line(ngx_http_request_t *r, ngx_table_elt_t *h,
+    ngx_uint_t offset)
+{
+    ngx_table_elt_t  **ph;
+
+    ph = (ngx_table_elt_t **) ((char *) &r->headers_in + offset);
+
+    if (*ph == NULL) {
+        *ph = h;
+    }
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_http_process_unique_header_line(ngx_http_request_t *r, ngx_table_elt_t *h,
+    ngx_uint_t offset)
+{
+    ngx_table_elt_t  **ph;
+
+    ph = (ngx_table_elt_t **) ((char *) &r->headers_in + offset);
+
+    if (*ph == NULL) {
+        *ph = h;
+        return NGX_OK;
+    }
+
+    ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,
+                  "client sent duplicate header line: \"%V: %V\", "
+                  "previous value: \"%V: %V\"",
+                  &h->key, &h->value, &(*ph)->key, &(*ph)->value);
+
+    ngx_http_finalize_request(r, NGX_HTTP_BAD_REQUEST);
+
+    return NGX_ERROR;
+}
+
+
+static ngx_int_t
+ngx_http_process_host(ngx_http_request_t *r, ngx_table_elt_t *h,
+    ngx_uint_t offset)
+{
+    ngx_int_t  rc;
+    ngx_str_t  host;
+
+    if (r->headers_in.host == NULL) {
+        r->headers_in.host = h;
+    }
+
+    host = h->value;
+
+    rc = ngx_http_validate_host(&host, r->pool, 0);
+
+    if (rc == NGX_DECLINED) {
+        ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,
+                      "client sent invalid host header");
+        ngx_http_finalize_request(r, NGX_HTTP_BAD_REQUEST);
+        return NGX_ERROR;
+    }
+
+    if (rc == NGX_ERROR) {
+        ngx_http_close_request(r, NGX_HTTP_INTERNAL_SERVER_ERROR);
+        return NGX_ERROR;
+    }
+
+    if (r->headers_in.server.len) {
+        return NGX_OK;
+    }
+
+    if (ngx_http_set_virtual_server(r, &host) == NGX_ERROR) {
+        return NGX_ERROR;
+    }
+
+    r->headers_in.server = host;
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_http_process_connection(ngx_http_request_t *r, ngx_table_elt_t *h,
+    ngx_uint_t offset)
+{
+    if (ngx_strcasestrn(h->value.data, "close", 5 - 1)) {
+        r->headers_in.connection_type = NGX_HTTP_CONNECTION_CLOSE;
+
+    } else if (ngx_strcasestrn(h->value.data, "keep-alive", 10 - 1)) {
+        r->headers_in.connection_type = NGX_HTTP_CONNECTION_KEEP_ALIVE;
+    }
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_http_process_user_agent(ngx_http_request_t *r, ngx_table_elt_t *h,
+    ngx_uint_t offset)
+{
+    u_char  *user_agent, *msie;
+
+    if (r->headers_in.user_agent) {
+        return NGX_OK;
+    }
+
+    r->headers_in.user_agent = h;
+
+    /* check some widespread browsers while the header is in CPU cache */
+
+    user_agent = h->value.data;
+
+    msie = ngx_strstrn(user_agent, "MSIE ", 5 - 1);
+
+    if (msie && msie + 7 < user_agent + h->value.len) {
+
+        r->headers_in.msie = 1;
+
+        if (msie[6] == '.') {
+
+            switch (msie[5]) {
+            case '4':
+            case '5':
+                r->headers_in.msie6 = 1;
+                break;
+            case '6':
+                if (ngx_strstrn(msie + 8, "SV1", 3 - 1) == NULL) {
+                    r->headers_in.msie6 = 1;
+                }
+                break;
+            }
+        }
+
+#if 0
+        /* MSIE ignores the SSL "close notify" alert */
+        if (c->ssl) {
+            c->ssl->no_send_shutdown = 1;
+        }
+#endif
+    }
+
+    if (ngx_strstrn(user_agent, "Opera", 5 - 1)) {
+        r->headers_in.opera = 1;
+        r->headers_in.msie = 0;
+        r->headers_in.msie6 = 0;
+    }
+
+    if (!r->headers_in.msie && !r->headers_in.opera) {
+
+        if (ngx_strstrn(user_agent, "Gecko/", 6 - 1)) {
+            r->headers_in.gecko = 1;
+
+        } else if (ngx_strstrn(user_agent, "Chrome/", 7 - 1)) {
+            r->headers_in.chrome = 1;
+
+        } else if (ngx_strstrn(user_agent, "Safari/", 7 - 1)
+                   && ngx_strstrn(user_agent, "Mac OS X", 8 - 1))
+        {
+            r->headers_in.safari = 1;
+
+        } else if (ngx_strstrn(user_agent, "Konqueror", 9 - 1)) {
+            r->headers_in.konqueror = 1;
+        }
+    }
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_http_process_multi_header_lines(ngx_http_request_t *r, ngx_table_elt_t *h,
+    ngx_uint_t offset)
+{
+    ngx_array_t       *headers;
+    ngx_table_elt_t  **ph;
+
+    headers = (ngx_array_t *) ((char *) &r->headers_in + offset);
+
+    if (headers->elts == NULL) {
+        if (ngx_array_init(headers, r->pool, 1, sizeof(ngx_table_elt_t *))
+            != NGX_OK)
+        {
+            ngx_http_close_request(r, NGX_HTTP_INTERNAL_SERVER_ERROR);
+            return NGX_ERROR;
+        }
+    }
+
+    ph = ngx_array_push(headers);
+    if (ph == NULL) {
+        ngx_http_close_request(r, NGX_HTTP_INTERNAL_SERVER_ERROR);
+        return NGX_ERROR;
+    }
+
+    *ph = h;
+    return NGX_OK;
+}
+
+
+ngx_int_t
+ngx_http_process_request_header(ngx_http_request_t *r)
+{
+    if (r->headers_in.server.len == 0
+        && ngx_http_set_virtual_server(r, &r->headers_in.server)
+           == NGX_ERROR)
+    {
+        return NGX_ERROR;
+    }
+
+    if (r->headers_in.host == NULL && r->http_version > NGX_HTTP_VERSION_10) {
+        ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,
+                   "client sent HTTP/1.1 request without \"Host\" header");
+        ngx_http_finalize_request(r, NGX_HTTP_BAD_REQUEST);
+        return NGX_ERROR;
+    }
+
+    if (r->headers_in.content_length) {
+        r->headers_in.content_length_n =
+                            ngx_atoof(r->headers_in.content_length->value.data,
+                                      r->headers_in.content_length->value.len);
+
+        if (r->headers_in.content_length_n == NGX_ERROR) {
+            ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,
+                          "client sent invalid \"Content-Length\" header");
+            ngx_http_finalize_request(r, NGX_HTTP_BAD_REQUEST);
+            return NGX_ERROR;
+        }
+    }
+
+    if (r->method == NGX_HTTP_TRACE) {
+        ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,
+                      "client sent TRACE method");
+        ngx_http_finalize_request(r, NGX_HTTP_NOT_ALLOWED);
+        return NGX_ERROR;
+    }
+
+    if (r->headers_in.transfer_encoding) {
+        if (r->headers_in.transfer_encoding->value.len == 7
+            && ngx_strncasecmp(r->headers_in.transfer_encoding->value.data,
+                               (u_char *) "chunked", 7) == 0)
+        {
+            r->headers_in.content_length = NULL;
+            r->headers_in.content_length_n = -1;
+            r->headers_in.chunked = 1;
+
+        } else if (r->headers_in.transfer_encoding->value.len != 8
+            || ngx_strncasecmp(r->headers_in.transfer_encoding->value.data,
+                               (u_char *) "identity", 8) != 0)
+        {
+            ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,
+                          "client sent unknown \"Transfer-Encoding\": \"%V\"",
+                          &r->headers_in.transfer_encoding->value);
+            ngx_http_finalize_request(r, NGX_HTTP_NOT_IMPLEMENTED);
+            return NGX_ERROR;
+        }
+    }
+
+    if (r->headers_in.connection_type == NGX_HTTP_CONNECTION_KEEP_ALIVE) {
+        if (r->headers_in.keep_alive) {
+            r->headers_in.keep_alive_n =
+                            ngx_atotm(r->headers_in.keep_alive->value.data,
+                                      r->headers_in.keep_alive->value.len);
+        }
+    }
+
+    return NGX_OK;
+}
+
+
+void
+ngx_http_process_request(ngx_http_request_t *r)
+{
+    ngx_connection_t  *c;
+
+    c = r->connection;
+
+#if (NGX_HTTP_SSL)
+
+    if (r->http_connection->ssl) {
+        long                      rc;
+        X509                     *cert;
+        ngx_http_ssl_srv_conf_t  *sscf;
+
+        if (c->ssl == NULL) {
+            ngx_log_error(NGX_LOG_INFO, c->log, 0,
+                          "client sent plain HTTP request to HTTPS port");
+            ngx_http_finalize_request(r, NGX_HTTP_TO_HTTPS);
+            return;
+        }
+
+        sscf = ngx_http_get_module_srv_conf(r, ngx_http_ssl_module);
+
+        if (sscf->verify) {
+            rc = SSL_get_verify_result(c->ssl->connection);
+
+            if (rc != X509_V_OK
+                && (sscf->verify != 3 || !ngx_ssl_verify_error_optional(rc)))
+            {
+                ngx_log_error(NGX_LOG_INFO, c->log, 0,
+                              "client SSL certificate verify error: (%l:%s)",
+                              rc, X509_verify_cert_error_string(rc));
+
+                ngx_ssl_remove_cached_session(c->ssl->session_ctx,
+                                       (SSL_get0_session(c->ssl->connection)));
+
+                ngx_http_finalize_request(r, NGX_HTTPS_CERT_ERROR);
+                return;
+            }
+
+            if (sscf->verify == 1) {
+                cert = SSL_get_peer_certificate(c->ssl->connection);
+                
+                if (cert == NULL) {
+                    ngx_log_error(NGX_LOG_INFO, c->log, 0,
+                                  "client sent no required SSL certificate");
+
+                    ngx_ssl_remove_cached_session(c->ssl->session_ctx,
+                                       (SSL_get0_session(c->ssl->connection)));
+
+                    ngx_http_finalize_request(r, NGX_HTTPS_NO_CERT);
+                    return;
+                }
+                
+                if (sscf->ssl_spiffe == 1) {
+                    ASN1_STRING             *str;
+                    GENERAL_NAME            *sanName;
+                    STACK_OF(GENERAL_NAME)  *san_names = NULL;
+                    ngx_str_t               *accepted_elts;
+                    ngx_uint_t              i, found;
+
+                    san_names = X509_get_ext_d2i((X509 *) cert, NID_subject_alt_name, NULL, NULL);
+                    sanName = sk_GENERAL_NAME_value(san_names, 0); 
+                    str = sanName->d.dNSName;
+    
+                    accepted_elts = sscf->ssl_spiffe_accept->elts;
+
+                    found = 0;
+                    // Vefify Spiffy id is in accepted list
+                    //
+                    for (i = 0; i < sscf->ssl_spiffe_accept->nelts; i++) {        
+                        if (ngx_strcmp(str->data, accepted_elts[i].data) == 0) {
+                            found = 1;
+                        
+                        }
+                    }
+
+                    if (found != 1 ) {
+                        ngx_log_error(NGX_LOG_INFO, c->log, 0,
+                                    "client spiffe id is no supported");
+
+                        ngx_ssl_remove_cached_session(c->ssl->session_ctx,
+                                            (SSL_get0_session(c->ssl->connection)));
+
+                        ngx_http_finalize_request(r, NGX_HTTPS_NO_CERT);
+                        return;
+                        
+                    }                    
+                                
+                }
+                
+                X509_free(cert);                               
+            }
+        }
+    }
+
+
+#endif
+
+    if (c->read->timer_set) {
+        ngx_del_timer(c->read);
+    }
+
+#if (NGX_STAT_STUB)
+    (void) ngx_atomic_fetch_add(ngx_stat_reading, -1);
+    r->stat_reading = 0;
+    (void) ngx_atomic_fetch_add(ngx_stat_writing, 1);
+    r->stat_writing = 1;
+#endif
+
+    c->read->handler = ngx_http_request_handler;
+    c->write->handler = ngx_http_request_handler;
+    r->read_event_handler = ngx_http_block_reading;
+
+    ngx_http_handler(r);
+
+    ngx_http_run_posted_requests(c);
+}
+
+
+static ngx_int_t
+ngx_http_validate_host(ngx_str_t *host, ngx_pool_t *pool, ngx_uint_t alloc)
+{
+    u_char  *h, ch;
+    size_t   i, dot_pos, host_len;
+
+    enum {
+        sw_usual = 0,
+        sw_literal,
+        sw_rest
+    } state;
+
+    dot_pos = host->len;
+    host_len = host->len;
+
+    h = host->data;
+
+    state = sw_usual;
+
+    for (i = 0; i < host->len; i++) {
+        ch = h[i];
+
+        switch (ch) {
+
+        case '.':
+            if (dot_pos == i - 1) {
+                return NGX_DECLINED;
+            }
+            dot_pos = i;
+            break;
+
+        case ':':
+            if (state == sw_usual) {
+                host_len = i;
+                state = sw_rest;
+            }
+            break;
+
+        case '[':
+            if (i == 0) {
+                state = sw_literal;
+            }
+            break;
+
+        case ']':
+            if (state == sw_literal) {
+                host_len = i + 1;
+                state = sw_rest;
+            }
+            break;
+
+        case '\0':
+            return NGX_DECLINED;
+
+        default:
+
+            if (ngx_path_separator(ch)) {
+                return NGX_DECLINED;
+            }
+
+            if (ch >= 'A' && ch <= 'Z') {
+                alloc = 1;
+            }
+
+            break;
+        }
+    }
+
+    if (dot_pos == host_len - 1) {
+        host_len--;
+    }
+
+    if (host_len == 0) {
+        return NGX_DECLINED;
+    }
+
+    if (alloc) {
+        host->data = ngx_pnalloc(pool, host_len);
+        if (host->data == NULL) {
+            return NGX_ERROR;
+        }
+
+        ngx_strlow(host->data, h, host_len);
+    }
+
+    host->len = host_len;
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_http_set_virtual_server(ngx_http_request_t *r, ngx_str_t *host)
+{
+    ngx_int_t                  rc;
+    ngx_http_connection_t     *hc;
+    ngx_http_core_loc_conf_t  *clcf;
+    ngx_http_core_srv_conf_t  *cscf;
+
+#if (NGX_SUPPRESS_WARN)
+    cscf = NULL;
+#endif
+
+    hc = r->http_connection;
+
+#if (NGX_HTTP_SSL && defined SSL_CTRL_SET_TLSEXT_HOSTNAME)
+
+    if (hc->ssl_servername) {
+        if (hc->ssl_servername->len == host->len
+            && ngx_strncmp(hc->ssl_servername->data,
+                           host->data, host->len) == 0)
+        {
+#if (NGX_PCRE)
+            if (hc->ssl_servername_regex
+                && ngx_http_regex_exec(r, hc->ssl_servername_regex,
+                                          hc->ssl_servername) != NGX_OK)
+            {
+                ngx_http_close_request(r, NGX_HTTP_INTERNAL_SERVER_ERROR);
+                return NGX_ERROR;
+            }
+#endif
+            return NGX_OK;
+        }
+    }
+
+#endif
+
+    rc = ngx_http_find_virtual_server(r->connection,
+                                      hc->addr_conf->virtual_names,
+                                      host, r, &cscf);
+
+    if (rc == NGX_ERROR) {
+        ngx_http_close_request(r, NGX_HTTP_INTERNAL_SERVER_ERROR);
+        return NGX_ERROR;
+    }
+
+#if (NGX_HTTP_SSL && defined SSL_CTRL_SET_TLSEXT_HOSTNAME)
+
+    if (hc->ssl_servername) {
+        ngx_http_ssl_srv_conf_t  *sscf;
+
+        if (rc == NGX_DECLINED) {
+            cscf = hc->addr_conf->default_server;
+            rc = NGX_OK;
+        }
+
+        sscf = ngx_http_get_module_srv_conf(cscf->ctx, ngx_http_ssl_module);
+
+        if (sscf->verify) {
+            ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,
+                          "client attempted to request the server name "
+                          "different from the one that was negotiated");
+            ngx_http_finalize_request(r, NGX_HTTP_MISDIRECTED_REQUEST);
+            return NGX_ERROR;
+        }
+    }
+
+#endif
+
+    if (rc == NGX_DECLINED) {
+        return NGX_OK;
+    }
+
+    r->srv_conf = cscf->ctx->srv_conf;
+    r->loc_conf = cscf->ctx->loc_conf;
+
+    clcf = ngx_http_get_module_loc_conf(r, ngx_http_core_module);
+
+    ngx_set_connection_log(r->connection, clcf->error_log);
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_http_find_virtual_server(ngx_connection_t *c,
+    ngx_http_virtual_names_t *virtual_names, ngx_str_t *host,
+    ngx_http_request_t *r, ngx_http_core_srv_conf_t **cscfp)
+{
+    ngx_http_core_srv_conf_t  *cscf;
+
+    if (virtual_names == NULL) {
+        return NGX_DECLINED;
+    }
+
+    cscf = ngx_hash_find_combined(&virtual_names->names,
+                                  ngx_hash_key(host->data, host->len),
+                                  host->data, host->len);
+
+    if (cscf) {
+        *cscfp = cscf;
+        return NGX_OK;
+    }
+
+#if (NGX_PCRE)
+
+    if (host->len && virtual_names->nregex) {
+        ngx_int_t                n;
+        ngx_uint_t               i;
+        ngx_http_server_name_t  *sn;
+
+        sn = virtual_names->regex;
+
+#if (NGX_HTTP_SSL && defined SSL_CTRL_SET_TLSEXT_HOSTNAME)
+
+        if (r == NULL) {
+            ngx_http_connection_t  *hc;
+
+            for (i = 0; i < virtual_names->nregex; i++) {
+
+                n = ngx_regex_exec(sn[i].regex->regex, host, NULL, 0);
+
+                if (n == NGX_REGEX_NO_MATCHED) {
+                    continue;
+                }
+
+                if (n >= 0) {
+                    hc = c->data;
+                    hc->ssl_servername_regex = sn[i].regex;
+
+                    *cscfp = sn[i].server;
+                    return NGX_OK;
+                }
+
+                ngx_log_error(NGX_LOG_ALERT, c->log, 0,
+                              ngx_regex_exec_n " failed: %i "
+                              "on \"%V\" using \"%V\"",
+                              n, host, &sn[i].regex->name);
+
+                return NGX_ERROR;
+            }
+
+            return NGX_DECLINED;
+        }
+
+#endif /* NGX_HTTP_SSL && defined SSL_CTRL_SET_TLSEXT_HOSTNAME */
+
+        for (i = 0; i < virtual_names->nregex; i++) {
+
+            n = ngx_http_regex_exec(r, sn[i].regex, host);
+
+            if (n == NGX_DECLINED) {
+                continue;
+            }
+
+            if (n == NGX_OK) {
+                *cscfp = sn[i].server;
+                return NGX_OK;
+            }
+
+            return NGX_ERROR;
+        }
+    }
+
+#endif /* NGX_PCRE */
+
+    return NGX_DECLINED;
+}
+
+
+static void
+ngx_http_request_handler(ngx_event_t *ev)
+{
+    ngx_connection_t    *c;
+    ngx_http_request_t  *r;
+
+    c = ev->data;
+    r = c->data;
+
+    ngx_http_set_log_request(c->log, r);
+
+    ngx_log_debug2(NGX_LOG_DEBUG_HTTP, c->log, 0,
+                   "http run request: \"%V?%V\"", &r->uri, &r->args);
+
+    if (c->close) {
+        r->main->count++;
+        ngx_http_terminate_request(r, 0);
+        ngx_http_run_posted_requests(c);
+        return;
+    }
+
+    if (ev->delayed && ev->timedout) {
+        ev->delayed = 0;
+        ev->timedout = 0;
+    }
+
+    if (ev->write) {
+        r->write_event_handler(r);
+
+    } else {
+        r->read_event_handler(r);
+    }
+
+    ngx_http_run_posted_requests(c);
+}
+
+
+void
+ngx_http_run_posted_requests(ngx_connection_t *c)
+{
+    ngx_http_request_t         *r;
+    ngx_http_posted_request_t  *pr;
+
+    for ( ;; ) {
+
+        if (c->destroyed) {
+            return;
+        }
+
+        r = c->data;
+        pr = r->main->posted_requests;
+
+        if (pr == NULL) {
+            return;
+        }
+
+        r->main->posted_requests = pr->next;
+
+        r = pr->request;
+
+        ngx_http_set_log_request(c->log, r);
+
+        ngx_log_debug2(NGX_LOG_DEBUG_HTTP, c->log, 0,
+                       "http posted request: \"%V?%V\"", &r->uri, &r->args);
+
+        r->write_event_handler(r);
+    }
+}
+
+
+ngx_int_t
+ngx_http_post_request(ngx_http_request_t *r, ngx_http_posted_request_t *pr)
+{
+    ngx_http_posted_request_t  **p;
+
+    if (pr == NULL) {
+        pr = ngx_palloc(r->pool, sizeof(ngx_http_posted_request_t));
+        if (pr == NULL) {
+            return NGX_ERROR;
+        }
+    }
+
+    pr->request = r;
+    pr->next = NULL;
+
+    for (p = &r->main->posted_requests; *p; p = &(*p)->next) { /* void */ }
+
+    *p = pr;
+
+    return NGX_OK;
+}
+
+
+void
+ngx_http_finalize_request(ngx_http_request_t *r, ngx_int_t rc)
+{
+    ngx_connection_t          *c;
+    ngx_http_request_t        *pr;
+    ngx_http_core_loc_conf_t  *clcf;
+
+    c = r->connection;
+
+    ngx_log_debug5(NGX_LOG_DEBUG_HTTP, c->log, 0,
+                   "http finalize request: %i, \"%V?%V\" a:%d, c:%d",
+                   rc, &r->uri, &r->args, r == c->data, r->main->count);
+
+    if (rc == NGX_DONE) {
+        ngx_http_finalize_connection(r);
+        return;
+    }
+
+    if (rc == NGX_OK && r->filter_finalize) {
+        c->error = 1;
+    }
+
+    if (rc == NGX_DECLINED) {
+        r->content_handler = NULL;
+        r->write_event_handler = ngx_http_core_run_phases;
+        ngx_http_core_run_phases(r);
+        return;
+    }
+
+    if (r != r->main && r->post_subrequest) {
+        rc = r->post_subrequest->handler(r, r->post_subrequest->data, rc);
+    }
+
+    if (rc == NGX_ERROR
+        || rc == NGX_HTTP_REQUEST_TIME_OUT
+        || rc == NGX_HTTP_CLIENT_CLOSED_REQUEST
+        || c->error)
+    {
+        if (ngx_http_post_action(r) == NGX_OK) {
+            return;
+        }
+
+        ngx_http_terminate_request(r, rc);
+        return;
+    }
+
+    if (rc >= NGX_HTTP_SPECIAL_RESPONSE
+        || rc == NGX_HTTP_CREATED
+        || rc == NGX_HTTP_NO_CONTENT)
+    {
+        if (rc == NGX_HTTP_CLOSE) {
+            ngx_http_terminate_request(r, rc);
+            return;
+        }
+
+        if (r == r->main) {
+            if (c->read->timer_set) {
+                ngx_del_timer(c->read);
+            }
+
+            if (c->write->timer_set) {
+                ngx_del_timer(c->write);
+            }
+        }
+
+        c->read->handler = ngx_http_request_handler;
+        c->write->handler = ngx_http_request_handler;
+
+        ngx_http_finalize_request(r, ngx_http_special_response_handler(r, rc));
+        return;
+    }
+
+    if (r != r->main) {
+        clcf = ngx_http_get_module_loc_conf(r, ngx_http_core_module);
+
+        if (r->background) {
+            if (!r->logged) {
+                if (clcf->log_subrequest) {
+                    ngx_http_log_request(r);
+                }
+
+                r->logged = 1;
+
+            } else {
+                ngx_log_error(NGX_LOG_ALERT, c->log, 0,
+                              "subrequest: \"%V?%V\" logged again",
+                              &r->uri, &r->args);
+            }
+
+            r->done = 1;
+            ngx_http_finalize_connection(r);
+            return;
+        }
+
+        if (r->buffered || r->postponed) {
+
+            if (ngx_http_set_write_handler(r) != NGX_OK) {
+                ngx_http_terminate_request(r, 0);
+            }
+
+            return;
+        }
+
+        pr = r->parent;
+
+        if (r == c->data) {
+
+            r->main->count--;
+
+            if (!r->logged) {
+                if (clcf->log_subrequest) {
+                    ngx_http_log_request(r);
+                }
+
+                r->logged = 1;
+
+            } else {
+                ngx_log_error(NGX_LOG_ALERT, c->log, 0,
+                              "subrequest: \"%V?%V\" logged again",
+                              &r->uri, &r->args);
+            }
+
+            r->done = 1;
+
+            if (pr->postponed && pr->postponed->request == r) {
+                pr->postponed = pr->postponed->next;
+            }
+
+            c->data = pr;
+
+        } else {
+
+            ngx_log_debug2(NGX_LOG_DEBUG_HTTP, c->log, 0,
+                           "http finalize non-active request: \"%V?%V\"",
+                           &r->uri, &r->args);
+
+            r->write_event_handler = ngx_http_request_finalizer;
+
+            if (r->waited) {
+                r->done = 1;
+            }
+        }
+
+        if (ngx_http_post_request(pr, NULL) != NGX_OK) {
+            r->main->count++;
+            ngx_http_terminate_request(r, 0);
+            return;
+        }
+
+        ngx_log_debug2(NGX_LOG_DEBUG_HTTP, c->log, 0,
+                       "http wake parent request: \"%V?%V\"",
+                       &pr->uri, &pr->args);
+
+        return;
+    }
+
+    if (r->buffered || c->buffered || r->postponed) {
+
+        if (ngx_http_set_write_handler(r) != NGX_OK) {
+            ngx_http_terminate_request(r, 0);
+        }
+
+        return;
+    }
+
+    if (r != c->data) {
+        ngx_log_error(NGX_LOG_ALERT, c->log, 0,
+                      "http finalize non-active request: \"%V?%V\"",
+                      &r->uri, &r->args);
+        return;
+    }
+
+    r->done = 1;
+
+    r->read_event_handler = ngx_http_block_reading;
+    r->write_event_handler = ngx_http_request_empty_handler;
+
+    if (!r->post_action) {
+        r->request_complete = 1;
+    }
+
+    if (ngx_http_post_action(r) == NGX_OK) {
+        return;
+    }
+
+    if (c->read->timer_set) {
+        ngx_del_timer(c->read);
+    }
+
+    if (c->write->timer_set) {
+        c->write->delayed = 0;
+        ngx_del_timer(c->write);
+    }
+
+    if (c->read->eof) {
+        ngx_http_close_request(r, 0);
+        return;
+    }
+
+    ngx_http_finalize_connection(r);
+}
+
+
+static void
+ngx_http_terminate_request(ngx_http_request_t *r, ngx_int_t rc)
+{
+    ngx_http_cleanup_t    *cln;
+    ngx_http_request_t    *mr;
+    ngx_http_ephemeral_t  *e;
+
+    mr = r->main;
+
+    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                   "http terminate request count:%d", mr->count);
+
+    if (rc > 0 && (mr->headers_out.status == 0 || mr->connection->sent == 0)) {
+        mr->headers_out.status = rc;
+    }
+
+    cln = mr->cleanup;
+    mr->cleanup = NULL;
+
+    while (cln) {
+        if (cln->handler) {
+            cln->handler(cln->data);
+        }
+
+        cln = cln->next;
+    }
+
+    ngx_log_debug2(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                   "http terminate cleanup count:%d blk:%d",
+                   mr->count, mr->blocked);
+
+    if (mr->write_event_handler) {
+
+        if (mr->blocked) {
+            r->connection->error = 1;
+            r->write_event_handler = ngx_http_request_finalizer;
+            return;
+        }
+
+        e = ngx_http_ephemeral(mr);
+        mr->posted_requests = NULL;
+        mr->write_event_handler = ngx_http_terminate_handler;
+        (void) ngx_http_post_request(mr, &e->terminal_posted_request);
+        return;
+    }
+
+    ngx_http_close_request(mr, rc);
+}
+
+
+static void
+ngx_http_terminate_handler(ngx_http_request_t *r)
+{
+    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                   "http terminate handler count:%d", r->count);
+
+    r->count = 1;
+
+    ngx_http_close_request(r, 0);
+}
+
+
+static void
+ngx_http_finalize_connection(ngx_http_request_t *r)
+{
+    ngx_http_core_loc_conf_t  *clcf;
+
+#if (NGX_HTTP_V2)
+    if (r->stream) {
+        ngx_http_close_request(r, 0);
+        return;
+    }
+#endif
+
+    clcf = ngx_http_get_module_loc_conf(r, ngx_http_core_module);
+
+    if (r->main->count != 1) {
+
+        if (r->discard_body) {
+            r->read_event_handler = ngx_http_discarded_request_body_handler;
+            ngx_add_timer(r->connection->read, clcf->lingering_timeout);
+
+            if (r->lingering_time == 0) {
+                r->lingering_time = ngx_time()
+                                      + (time_t) (clcf->lingering_time / 1000);
+            }
+        }
+
+        ngx_http_close_request(r, 0);
+        return;
+    }
+
+    r = r->main;
+
+    if (r->reading_body) {
+        r->keepalive = 0;
+        r->lingering_close = 1;
+    }
+
+    if (!ngx_terminate
+         && !ngx_exiting
+         && r->keepalive
+         && clcf->keepalive_timeout > 0)
+    {
+        ngx_http_set_keepalive(r);
+        return;
+    }
+
+    if (clcf->lingering_close == NGX_HTTP_LINGERING_ALWAYS
+        || (clcf->lingering_close == NGX_HTTP_LINGERING_ON
+            && (r->lingering_close
+                || r->header_in->pos < r->header_in->last
+                || r->connection->read->ready)))
+    {
+        ngx_http_set_lingering_close(r);
+        return;
+    }
+
+    ngx_http_close_request(r, 0);
+}
+
+
+static ngx_int_t
+ngx_http_set_write_handler(ngx_http_request_t *r)
+{
+    ngx_event_t               *wev;
+    ngx_http_core_loc_conf_t  *clcf;
+
+    r->http_state = NGX_HTTP_WRITING_REQUEST_STATE;
+
+    r->read_event_handler = r->discard_body ?
+                                ngx_http_discarded_request_body_handler:
+                                ngx_http_test_reading;
+    r->write_event_handler = ngx_http_writer;
+
+    wev = r->connection->write;
+
+    if (wev->ready && wev->delayed) {
+        return NGX_OK;
+    }
+
+    clcf = ngx_http_get_module_loc_conf(r, ngx_http_core_module);
+    if (!wev->delayed) {
+        ngx_add_timer(wev, clcf->send_timeout);
+    }
+
+    if (ngx_handle_write_event(wev, clcf->send_lowat) != NGX_OK) {
+        ngx_http_close_request(r, 0);
+        return NGX_ERROR;
+    }
+
+    return NGX_OK;
+}
+
+
+static void
+ngx_http_writer(ngx_http_request_t *r)
+{
+    ngx_int_t                  rc;
+    ngx_event_t               *wev;
+    ngx_connection_t          *c;
+    ngx_http_core_loc_conf_t  *clcf;
+
+    c = r->connection;
+    wev = c->write;
+
+    ngx_log_debug2(NGX_LOG_DEBUG_HTTP, wev->log, 0,
+                   "http writer handler: \"%V?%V\"", &r->uri, &r->args);
+
+    clcf = ngx_http_get_module_loc_conf(r->main, ngx_http_core_module);
+
+    if (wev->timedout) {
+        ngx_log_error(NGX_LOG_INFO, c->log, NGX_ETIMEDOUT,
+                      "client timed out");
+        c->timedout = 1;
+
+        ngx_http_finalize_request(r, NGX_HTTP_REQUEST_TIME_OUT);
+        return;
+    }
+
+    if (wev->delayed || r->aio) {
+        ngx_log_debug0(NGX_LOG_DEBUG_HTTP, wev->log, 0,
+                       "http writer delayed");
+
+        if (!wev->delayed) {
+            ngx_add_timer(wev, clcf->send_timeout);
+        }
+
+        if (ngx_handle_write_event(wev, clcf->send_lowat) != NGX_OK) {
+            ngx_http_close_request(r, 0);
+        }
+
+        return;
+    }
+
+    rc = ngx_http_output_filter(r, NULL);
+
+    ngx_log_debug3(NGX_LOG_DEBUG_HTTP, c->log, 0,
+                   "http writer output filter: %i, \"%V?%V\"",
+                   rc, &r->uri, &r->args);
+
+    if (rc == NGX_ERROR) {
+        ngx_http_finalize_request(r, rc);
+        return;
+    }
+
+    if (r->buffered || r->postponed || (r == r->main && c->buffered)) {
+
+        if (!wev->delayed) {
+            ngx_add_timer(wev, clcf->send_timeout);
+        }
+
+        if (ngx_handle_write_event(wev, clcf->send_lowat) != NGX_OK) {
+            ngx_http_close_request(r, 0);
+        }
+
+        return;
+    }
+
+    ngx_log_debug2(NGX_LOG_DEBUG_HTTP, wev->log, 0,
+                   "http writer done: \"%V?%V\"", &r->uri, &r->args);
+
+    r->write_event_handler = ngx_http_request_empty_handler;
+
+    ngx_http_finalize_request(r, rc);
+}
+
+
+static void
+ngx_http_request_finalizer(ngx_http_request_t *r)
+{
+    ngx_log_debug2(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                   "http finalizer done: \"%V?%V\"", &r->uri, &r->args);
+
+    ngx_http_finalize_request(r, 0);
+}
+
+
+void
+ngx_http_block_reading(ngx_http_request_t *r)
+{
+    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                   "http reading blocked");
+
+    /* aio does not call this handler */
+
+    if ((ngx_event_flags & NGX_USE_LEVEL_EVENT)
+        && r->connection->read->active)
+    {
+        if (ngx_del_event(r->connection->read, NGX_READ_EVENT, 0) != NGX_OK) {
+            ngx_http_close_request(r, 0);
+        }
+    }
+}
+
+
+void
+ngx_http_test_reading(ngx_http_request_t *r)
+{
+    int                n;
+    char               buf[1];
+    ngx_err_t          err;
+    ngx_event_t       *rev;
+    ngx_connection_t  *c;
+
+    c = r->connection;
+    rev = c->read;
+
+    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, c->log, 0, "http test reading");
+
+#if (NGX_HTTP_V2)
+
+    if (r->stream) {
+        if (c->error) {
+            err = 0;
+            goto closed;
+        }
+
+        return;
+    }
+
+#endif
+
+#if (NGX_HAVE_KQUEUE)
+
+    if (ngx_event_flags & NGX_USE_KQUEUE_EVENT) {
+
+        if (!rev->pending_eof) {
+            return;
+        }
+
+        rev->eof = 1;
+        c->error = 1;
+        err = rev->kq_errno;
+
+        goto closed;
+    }
+
+#endif
+
+#if (NGX_HAVE_EPOLLRDHUP)
+
+    if ((ngx_event_flags & NGX_USE_EPOLL_EVENT) && ngx_use_epoll_rdhup) {
+        socklen_t  len;
+
+        if (!rev->pending_eof) {
+            return;
+        }
+
+        rev->eof = 1;
+        c->error = 1;
+
+        err = 0;
+        len = sizeof(ngx_err_t);
+
+        /*
+         * BSDs and Linux return 0 and set a pending error in err
+         * Solaris returns -1 and sets errno
+         */
+
+        if (getsockopt(c->fd, SOL_SOCKET, SO_ERROR, (void *) &err, &len)
+            == -1)
+        {
+            err = ngx_socket_errno;
+        }
+
+        goto closed;
+    }
+
+#endif
+
+    n = recv(c->fd, buf, 1, MSG_PEEK);
+
+    if (n == 0) {
+        rev->eof = 1;
+        c->error = 1;
+        err = 0;
+
+        goto closed;
+
+    } else if (n == -1) {
+        err = ngx_socket_errno;
+
+        if (err != NGX_EAGAIN) {
+            rev->eof = 1;
+            c->error = 1;
+
+            goto closed;
+        }
+    }
+
+    /* aio does not call this handler */
+
+    if ((ngx_event_flags & NGX_USE_LEVEL_EVENT) && rev->active) {
+
+        if (ngx_del_event(rev, NGX_READ_EVENT, 0) != NGX_OK) {
+            ngx_http_close_request(r, 0);
+        }
+    }
+
+    return;
+
+closed:
+
+    if (err) {
+        rev->error = 1;
+    }
+
+    ngx_log_error(NGX_LOG_INFO, c->log, err,
+                  "client prematurely closed connection");
+
+    ngx_http_finalize_request(r, NGX_HTTP_CLIENT_CLOSED_REQUEST);
+}
+
+
+static void
+ngx_http_set_keepalive(ngx_http_request_t *r)
+{
+    int                        tcp_nodelay;
+    ngx_buf_t                 *b, *f;
+    ngx_chain_t               *cl, *ln;
+    ngx_event_t               *rev, *wev;
+    ngx_connection_t          *c;
+    ngx_http_connection_t     *hc;
+    ngx_http_core_loc_conf_t  *clcf;
+
+    c = r->connection;
+    rev = c->read;
+
+    clcf = ngx_http_get_module_loc_conf(r, ngx_http_core_module);
+
+    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, c->log, 0, "set http keepalive handler");
+
+    if (r->discard_body) {
+        r->write_event_handler = ngx_http_request_empty_handler;
+        r->lingering_time = ngx_time() + (time_t) (clcf->lingering_time / 1000);
+        ngx_add_timer(rev, clcf->lingering_timeout);
+        return;
+    }
+
+    c->log->action = "closing request";
+
+    hc = r->http_connection;
+    b = r->header_in;
+
+    if (b->pos < b->last) {
+
+        /* the pipelined request */
+
+        if (b != c->buffer) {
+
+            /*
+             * If the large header buffers were allocated while the previous
+             * request processing then we do not use c->buffer for
+             * the pipelined request (see ngx_http_create_request()).
+             *
+             * Now we would move the large header buffers to the free list.
+             */
+
+            for (cl = hc->busy; cl; /* void */) {
+                ln = cl;
+                cl = cl->next;
+
+                if (ln->buf == b) {
+                    ngx_free_chain(c->pool, ln);
+                    continue;
+                }
+
+                f = ln->buf;
+                f->pos = f->start;
+                f->last = f->start;
+
+                ln->next = hc->free;
+                hc->free = ln;
+            }
+
+            cl = ngx_alloc_chain_link(c->pool);
+            if (cl == NULL) {
+                ngx_http_close_request(r, 0);
+                return;
+            }
+
+            cl->buf = b;
+            cl->next = NULL;
+
+            hc->busy = cl;
+            hc->nbusy = 1;
+        }
+    }
+
+    /* guard against recursive call from ngx_http_finalize_connection() */
+    r->keepalive = 0;
+
+    ngx_http_free_request(r, 0);
+
+    c->data = hc;
+
+    if (ngx_handle_read_event(rev, 0) != NGX_OK) {
+        ngx_http_close_connection(c);
+        return;
+    }
+
+    wev = c->write;
+    wev->handler = ngx_http_empty_handler;
+
+    if (b->pos < b->last) {
+
+        ngx_log_debug0(NGX_LOG_DEBUG_HTTP, c->log, 0, "pipelined request");
+
+        c->log->action = "reading client pipelined request line";
+
+        r = ngx_http_create_request(c);
+        if (r == NULL) {
+            ngx_http_close_connection(c);
+            return;
+        }
+
+        r->pipeline = 1;
+
+        c->data = r;
+
+        c->sent = 0;
+        c->destroyed = 0;
+
+        if (rev->timer_set) {
+            ngx_del_timer(rev);
+        }
+
+        rev->handler = ngx_http_process_request_line;
+        ngx_post_event(rev, &ngx_posted_events);
+        return;
+    }
+
+    /*
+     * To keep a memory footprint as small as possible for an idle keepalive
+     * connection we try to free c->buffer's memory if it was allocated outside
+     * the c->pool.  The large header buffers are always allocated outside the
+     * c->pool and are freed too.
+     */
+
+    b = c->buffer;
+
+    if (ngx_pfree(c->pool, b->start) == NGX_OK) {
+
+        /*
+         * the special note for ngx_http_keepalive_handler() that
+         * c->buffer's memory was freed
+         */
+
+        b->pos = NULL;
+
+    } else {
+        b->pos = b->start;
+        b->last = b->start;
+    }
+
+    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, c->log, 0, "hc free: %p",
+                   hc->free);
+
+    if (hc->free) {
+        for (cl = hc->free; cl; /* void */) {
+            ln = cl;
+            cl = cl->next;
+            ngx_pfree(c->pool, ln->buf->start);
+            ngx_free_chain(c->pool, ln);
+        }
+
+        hc->free = NULL;
+    }
+
+    ngx_log_debug2(NGX_LOG_DEBUG_HTTP, c->log, 0, "hc busy: %p %i",
+                   hc->busy, hc->nbusy);
+
+    if (hc->busy) {
+        for (cl = hc->busy; cl; /* void */) {
+            ln = cl;
+            cl = cl->next;
+            ngx_pfree(c->pool, ln->buf->start);
+            ngx_free_chain(c->pool, ln);
+        }
+
+        hc->busy = NULL;
+        hc->nbusy = 0;
+    }
+
+#if (NGX_HTTP_SSL)
+    if (c->ssl) {
+        ngx_ssl_free_buffer(c);
+    }
+#endif
+
+    rev->handler = ngx_http_keepalive_handler;
+
+    if (wev->active && (ngx_event_flags & NGX_USE_LEVEL_EVENT)) {
+        if (ngx_del_event(wev, NGX_WRITE_EVENT, 0) != NGX_OK) {
+            ngx_http_close_connection(c);
+            return;
+        }
+    }
+
+    c->log->action = "keepalive";
+
+    if (c->tcp_nopush == NGX_TCP_NOPUSH_SET) {
+        if (ngx_tcp_push(c->fd) == -1) {
+            ngx_connection_error(c, ngx_socket_errno, ngx_tcp_push_n " failed");
+            ngx_http_close_connection(c);
+            return;
+        }
+
+        c->tcp_nopush = NGX_TCP_NOPUSH_UNSET;
+        tcp_nodelay = ngx_tcp_nodelay_and_tcp_nopush ? 1 : 0;
+
+    } else {
+        tcp_nodelay = 1;
+    }
+
+    if (tcp_nodelay && clcf->tcp_nodelay && ngx_tcp_nodelay(c) != NGX_OK) {
+        ngx_http_close_connection(c);
+        return;
+    }
+
+#if 0
+    /* if ngx_http_request_t was freed then we need some other place */
+    r->http_state = NGX_HTTP_KEEPALIVE_STATE;
+#endif
+
+    c->idle = 1;
+    ngx_reusable_connection(c, 1);
+
+    ngx_add_timer(rev, clcf->keepalive_timeout);
+
+    if (rev->ready) {
+        ngx_post_event(rev, &ngx_posted_events);
+    }
+}
+
+
+static void
+ngx_http_keepalive_handler(ngx_event_t *rev)
+{
+    size_t             size;
+    ssize_t            n;
+    ngx_buf_t         *b;
+    ngx_connection_t  *c;
+
+    c = rev->data;
+
+    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, c->log, 0, "http keepalive handler");
+
+    if (rev->timedout || c->close) {
+        ngx_http_close_connection(c);
+        return;
+    }
+
+#if (NGX_HAVE_KQUEUE)
+
+    if (ngx_event_flags & NGX_USE_KQUEUE_EVENT) {
+        if (rev->pending_eof) {
+            c->log->handler = NULL;
+            ngx_log_error(NGX_LOG_INFO, c->log, rev->kq_errno,
+                          "kevent() reported that client %V closed "
+                          "keepalive connection", &c->addr_text);
+#if (NGX_HTTP_SSL)
+            if (c->ssl) {
+                c->ssl->no_send_shutdown = 1;
+            }
+#endif
+            ngx_http_close_connection(c);
+            return;
+        }
+    }
+
+#endif
+
+    b = c->buffer;
+    size = b->end - b->start;
+
+    if (b->pos == NULL) {
+
+        /*
+         * The c->buffer's memory was freed by ngx_http_set_keepalive().
+         * However, the c->buffer->start and c->buffer->end were not changed
+         * to keep the buffer size.
+         */
+
+        b->pos = ngx_palloc(c->pool, size);
+        if (b->pos == NULL) {
+            ngx_http_close_connection(c);
+            return;
+        }
+
+        b->start = b->pos;
+        b->last = b->pos;
+        b->end = b->pos + size;
+    }
+
+    /*
+     * MSIE closes a keepalive connection with RST flag
+     * so we ignore ECONNRESET here.
+     */
+
+    c->log_error = NGX_ERROR_IGNORE_ECONNRESET;
+    ngx_set_socket_errno(0);
+
+    n = c->recv(c, b->last, size);
+    c->log_error = NGX_ERROR_INFO;
+
+    if (n == NGX_AGAIN) {
+        if (ngx_handle_read_event(rev, 0) != NGX_OK) {
+            ngx_http_close_connection(c);
+            return;
+        }
+
+        /*
+         * Like ngx_http_set_keepalive() we are trying to not hold
+         * c->buffer's memory for a keepalive connection.
+         */
+
+        if (ngx_pfree(c->pool, b->start) == NGX_OK) {
+
+            /*
+             * the special note that c->buffer's memory was freed
+             */
+
+            b->pos = NULL;
+        }
+
+        return;
+    }
+
+    if (n == NGX_ERROR) {
+        ngx_http_close_connection(c);
+        return;
+    }
+
+    c->log->handler = NULL;
+
+    if (n == 0) {
+        ngx_log_error(NGX_LOG_INFO, c->log, ngx_socket_errno,
+                      "client %V closed keepalive connection", &c->addr_text);
+        ngx_http_close_connection(c);
+        return;
+    }
+
+    b->last += n;
+
+    c->log->handler = ngx_http_log_error;
+    c->log->action = "reading client request line";
+
+    c->idle = 0;
+    ngx_reusable_connection(c, 0);
+
+    c->data = ngx_http_create_request(c);
+    if (c->data == NULL) {
+        ngx_http_close_connection(c);
+        return;
+    }
+
+    c->sent = 0;
+    c->destroyed = 0;
+
+    ngx_del_timer(rev);
+
+    rev->handler = ngx_http_process_request_line;
+    ngx_http_process_request_line(rev);
+}
+
+
+static void
+ngx_http_set_lingering_close(ngx_http_request_t *r)
+{
+    ngx_event_t               *rev, *wev;
+    ngx_connection_t          *c;
+    ngx_http_core_loc_conf_t  *clcf;
+
+    c = r->connection;
+
+    clcf = ngx_http_get_module_loc_conf(r, ngx_http_core_module);
+
+    rev = c->read;
+    rev->handler = ngx_http_lingering_close_handler;
+
+    r->lingering_time = ngx_time() + (time_t) (clcf->lingering_time / 1000);
+    ngx_add_timer(rev, clcf->lingering_timeout);
+
+    if (ngx_handle_read_event(rev, 0) != NGX_OK) {
+        ngx_http_close_request(r, 0);
+        return;
+    }
+
+    wev = c->write;
+    wev->handler = ngx_http_empty_handler;
+
+    if (wev->active && (ngx_event_flags & NGX_USE_LEVEL_EVENT)) {
+        if (ngx_del_event(wev, NGX_WRITE_EVENT, 0) != NGX_OK) {
+            ngx_http_close_request(r, 0);
+            return;
+        }
+    }
+
+    if (ngx_shutdown_socket(c->fd, NGX_WRITE_SHUTDOWN) == -1) {
+        ngx_connection_error(c, ngx_socket_errno,
+                             ngx_shutdown_socket_n " failed");
+        ngx_http_close_request(r, 0);
+        return;
+    }
+
+    if (rev->ready) {
+        ngx_http_lingering_close_handler(rev);
+    }
+}
+
+
+static void
+ngx_http_lingering_close_handler(ngx_event_t *rev)
+{
+    ssize_t                    n;
+    ngx_msec_t                 timer;
+    ngx_connection_t          *c;
+    ngx_http_request_t        *r;
+    ngx_http_core_loc_conf_t  *clcf;
+    u_char                     buffer[NGX_HTTP_LINGERING_BUFFER_SIZE];
+
+    c = rev->data;
+    r = c->data;
+
+    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, c->log, 0,
+                   "http lingering close handler");
+
+    if (rev->timedout) {
+        ngx_http_close_request(r, 0);
+        return;
+    }
+
+    timer = (ngx_msec_t) r->lingering_time - (ngx_msec_t) ngx_time();
+    if ((ngx_msec_int_t) timer <= 0) {
+        ngx_http_close_request(r, 0);
+        return;
+    }
+
+    do {
+        n = c->recv(c, buffer, NGX_HTTP_LINGERING_BUFFER_SIZE);
+
+        ngx_log_debug1(NGX_LOG_DEBUG_HTTP, c->log, 0, "lingering read: %z", n);
+
+        if (n == NGX_ERROR || n == 0) {
+            ngx_http_close_request(r, 0);
+            return;
+        }
+
+    } while (rev->ready);
+
+    if (ngx_handle_read_event(rev, 0) != NGX_OK) {
+        ngx_http_close_request(r, 0);
+        return;
+    }
+
+    clcf = ngx_http_get_module_loc_conf(r, ngx_http_core_module);
+
+    timer *= 1000;
+
+    if (timer > clcf->lingering_timeout) {
+        timer = clcf->lingering_timeout;
+    }
+
+    ngx_add_timer(rev, timer);
+}
+
+
+void
+ngx_http_empty_handler(ngx_event_t *wev)
+{
+    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, wev->log, 0, "http empty handler");
+
+    return;
+}
+
+
+void
+ngx_http_request_empty_handler(ngx_http_request_t *r)
+{
+    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                   "http request empty handler");
+
+    return;
+}
+
+
+ngx_int_t
+ngx_http_send_special(ngx_http_request_t *r, ngx_uint_t flags)
+{
+    ngx_buf_t    *b;
+    ngx_chain_t   out;
+
+    b = ngx_calloc_buf(r->pool);
+    if (b == NULL) {
+        return NGX_ERROR;
+    }
+
+    if (flags & NGX_HTTP_LAST) {
+
+        if (r == r->main && !r->post_action) {
+            b->last_buf = 1;
+
+        } else {
+            b->sync = 1;
+            b->last_in_chain = 1;
+        }
+    }
+
+    if (flags & NGX_HTTP_FLUSH) {
+        b->flush = 1;
+    }
+
+    out.buf = b;
+    out.next = NULL;
+
+    return ngx_http_output_filter(r, &out);
+}
+
+
+static ngx_int_t
+ngx_http_post_action(ngx_http_request_t *r)
+{
+    ngx_http_core_loc_conf_t  *clcf;
+
+    clcf = ngx_http_get_module_loc_conf(r, ngx_http_core_module);
+
+    if (clcf->post_action.data == NULL) {
+        return NGX_DECLINED;
+    }
+
+    if (r->post_action && r->uri_changes == 0) {
+        return NGX_DECLINED;
+    }
+
+    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                   "post action: \"%V\"", &clcf->post_action);
+
+    r->main->count--;
+
+    r->http_version = NGX_HTTP_VERSION_9;
+    r->header_only = 1;
+    r->post_action = 1;
+
+    r->read_event_handler = ngx_http_block_reading;
+
+    if (clcf->post_action.data[0] == '/') {
+        ngx_http_internal_redirect(r, &clcf->post_action, NULL);
+
+    } else {
+        ngx_http_named_location(r, &clcf->post_action);
+    }
+
+    return NGX_OK;
+}
+
+
+static void
+ngx_http_close_request(ngx_http_request_t *r, ngx_int_t rc)
+{
+    ngx_connection_t  *c;
+
+    r = r->main;
+    c = r->connection;
+
+    ngx_log_debug2(NGX_LOG_DEBUG_HTTP, c->log, 0,
+                   "http request count:%d blk:%d", r->count, r->blocked);
+
+    if (r->count == 0) {
+        ngx_log_error(NGX_LOG_ALERT, c->log, 0, "http request count is zero");
+    }
+
+    r->count--;
+
+    if (r->count || r->blocked) {
+        return;
+    }
+
+#if (NGX_HTTP_V2)
+    if (r->stream) {
+        ngx_http_v2_close_stream(r->stream, rc);
+        return;
+    }
+#endif
+
+    ngx_http_free_request(r, rc);
+    ngx_http_close_connection(c);
+}
+
+
+void
+ngx_http_free_request(ngx_http_request_t *r, ngx_int_t rc)
+{
+    ngx_log_t                 *log;
+    ngx_pool_t                *pool;
+    struct linger              linger;
+    ngx_http_cleanup_t        *cln;
+    ngx_http_log_ctx_t        *ctx;
+    ngx_http_core_loc_conf_t  *clcf;
+
+    log = r->connection->log;
+
+    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, log, 0, "http close request");
+
+    if (r->pool == NULL) {
+        ngx_log_error(NGX_LOG_ALERT, log, 0, "http request already closed");
+        return;
+    }
+
+    cln = r->cleanup;
+    r->cleanup = NULL;
+
+    while (cln) {
+        if (cln->handler) {
+            cln->handler(cln->data);
+        }
+
+        cln = cln->next;
+    }
+
+#if (NGX_STAT_STUB)
+
+    if (r->stat_reading) {
+        (void) ngx_atomic_fetch_add(ngx_stat_reading, -1);
+    }
+
+    if (r->stat_writing) {
+        (void) ngx_atomic_fetch_add(ngx_stat_writing, -1);
+    }
+
+#endif
+
+    if (rc > 0 && (r->headers_out.status == 0 || r->connection->sent == 0)) {
+        r->headers_out.status = rc;
+    }
+
+    log->action = "logging request";
+
+    ngx_http_log_request(r);
+
+    log->action = "closing request";
+
+    if (r->connection->timedout) {
+        clcf = ngx_http_get_module_loc_conf(r, ngx_http_core_module);
+
+        if (clcf->reset_timedout_connection) {
+            linger.l_onoff = 1;
+            linger.l_linger = 0;
+
+            if (setsockopt(r->connection->fd, SOL_SOCKET, SO_LINGER,
+                           (const void *) &linger, sizeof(struct linger)) == -1)
+            {
+                ngx_log_error(NGX_LOG_ALERT, log, ngx_socket_errno,
+                              "setsockopt(SO_LINGER) failed");
+            }
+        }
+    }
+
+    /* the various request strings were allocated from r->pool */
+    ctx = log->data;
+    ctx->request = NULL;
+
+    r->request_line.len = 0;
+
+    r->connection->destroyed = 1;
+
+    /*
+     * Setting r->pool to NULL will increase probability to catch double close
+     * of request since the request object is allocated from its own pool.
+     */
+
+    pool = r->pool;
+    r->pool = NULL;
+
+    ngx_destroy_pool(pool);
+}
+
+
+static void
+ngx_http_log_request(ngx_http_request_t *r)
+{
+    ngx_uint_t                  i, n;
+    ngx_http_handler_pt        *log_handler;
+    ngx_http_core_main_conf_t  *cmcf;
+
+    cmcf = ngx_http_get_module_main_conf(r, ngx_http_core_module);
+
+    log_handler = cmcf->phases[NGX_HTTP_LOG_PHASE].handlers.elts;
+    n = cmcf->phases[NGX_HTTP_LOG_PHASE].handlers.nelts;
+
+    for (i = 0; i < n; i++) {
+        log_handler[i](r);
+    }
+}
+
+
+void
+ngx_http_close_connection(ngx_connection_t *c)
+{
+    ngx_pool_t  *pool;
+
+    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, c->log, 0,
+                   "close http connection: %d", c->fd);
+
+#if (NGX_HTTP_SSL)
+
+    if (c->ssl) {
+        if (ngx_ssl_shutdown(c) == NGX_AGAIN) {
+            c->ssl->handler = ngx_http_close_connection;
+            return;
+        }
+    }
+
+#endif
+
+#if (NGX_STAT_STUB)
+    (void) ngx_atomic_fetch_add(ngx_stat_active, -1);
+#endif
+
+    c->destroyed = 1;
+
+    pool = c->pool;
+
+    ngx_close_connection(c);
+
+    ngx_destroy_pool(pool);
+}
+
+
+static u_char *
+ngx_http_log_error(ngx_log_t *log, u_char *buf, size_t len)
+{
+    u_char              *p;
+    ngx_http_request_t  *r;
+    ngx_http_log_ctx_t  *ctx;
+
+    if (log->action) {
+        p = ngx_snprintf(buf, len, " while %s", log->action);
+        len -= p - buf;
+        buf = p;
+    }
+
+    ctx = log->data;
+
+    p = ngx_snprintf(buf, len, ", client: %V", &ctx->connection->addr_text);
+    len -= p - buf;
+
+    r = ctx->request;
+
+    if (r) {
+        return r->log_handler(r, ctx->current_request, p, len);
+
+    } else {
+        p = ngx_snprintf(p, len, ", server: %V",
+                         &ctx->connection->listening->addr_text);
+    }
+
+    return p;
+}
+
+
+static u_char *
+ngx_http_log_error_handler(ngx_http_request_t *r, ngx_http_request_t *sr,
+    u_char *buf, size_t len)
+{
+    char                      *uri_separator;
+    u_char                    *p;
+    ngx_http_upstream_t       *u;
+    ngx_http_core_srv_conf_t  *cscf;
+
+    cscf = ngx_http_get_module_srv_conf(r, ngx_http_core_module);
+
+    p = ngx_snprintf(buf, len, ", server: %V", &cscf->server_name);
+    len -= p - buf;
+    buf = p;
+
+    if (r->request_line.data == NULL && r->request_start) {
+        for (p = r->request_start; p < r->header_in->last; p++) {
+            if (*p == CR || *p == LF) {
+                break;
+            }
+        }
+
+        r->request_line.len = p - r->request_start;
+        r->request_line.data = r->request_start;
+    }
+
+    if (r->request_line.len) {
+        p = ngx_snprintf(buf, len, ", request: \"%V\"", &r->request_line);
+        len -= p - buf;
+        buf = p;
+    }
+
+    if (r != sr) {
+        p = ngx_snprintf(buf, len, ", subrequest: \"%V\"", &sr->uri);
+        len -= p - buf;
+        buf = p;
+    }
+
+    u = sr->upstream;
+
+    if (u && u->peer.name) {
+
+        uri_separator = "";
+
+#if (NGX_HAVE_UNIX_DOMAIN)
+        if (u->peer.sockaddr && u->peer.sockaddr->sa_family == AF_UNIX) {
+            uri_separator = ":";
+        }
+#endif
+
+        p = ngx_snprintf(buf, len, ", upstream: \"%V%V%s%V\"",
+                         &u->schema, u->peer.name,
+                         uri_separator, &u->uri);
+        len -= p - buf;
+        buf = p;
+    }
+
+    if (r->headers_in.host) {
+        p = ngx_snprintf(buf, len, ", host: \"%V\"",
+                         &r->headers_in.host->value);
+        len -= p - buf;
+        buf = p;
+    }
+
+    if (r->headers_in.referer) {
+        p = ngx_snprintf(buf, len, ", referrer: \"%V\"",
+                         &r->headers_in.referer->value);
+        buf = p;
+    }
+
+    return buf;
+}

--- a/spire_agent.conf
+++ b/spire_agent.conf
@@ -1,0 +1,54 @@
+agent {
+    bind_address = "127.0.0.1"
+    bind_port = "8088"
+    data_dir = "."
+    log_level = "DEBUG"
+    plugin_dir = "conf/agent/plugin"
+    server_address = "127.0.0.1"
+    server_port = "8081"
+    socket_path ="/tmp/agent.sock"
+    trust_bundle_path = "conf/agent/dummy_root_ca.crt"
+    trust_domain = "example.org"
+    umask = ""
+    join_token = ""
+}
+
+plugins {
+    NodeAttestor "join_token" {
+        plugin_cmd = "plugin/agent/nodeattestor-jointoken"
+        plugin_checksum = ""
+        enabled = true
+        plugin_data {
+            trust_domain = "example.org"
+        }
+    }
+    KeyManager "km_memory" {
+        plugin_cmd = "plugin/agent/keymanager-memory"
+        plugin_checksum = ""
+        enabled = true
+        plugin_data {
+        }
+    }
+    WorkloadAttestor "wla_k8s" {
+        plugin_cmd = "plugin/agent/workloadattestor-k8s"
+        plugin_checksum = ""
+        enabled = true
+        plugin_data {
+            kubelet_read_only_port = "10255"
+        }
+    }
+    WorkloadAttestor "wla_secret_file" {
+        plugin_cmd = "plugin/agent/workloadattestor-secretfile"
+        plugin_checksum = ""
+        enabled = true
+        plugin_data {
+        }
+    }
+    WorkloadAttestor "wla_unix" {
+        plugin_cmd = "plugin/agent/workloadattestor-unix"
+        plugin_checksum = ""
+        enabled = true
+        plugin_data {
+        }
+    }
+}

--- a/spire_server.conf
+++ b/spire_server.conf
@@ -1,0 +1,65 @@
+server {
+    bind_address = "127.0.0.1"
+    bind_port = "8081"
+    bind_http_port = "8080"
+    trust_domain = "example.org"
+    plugin_dir = "conf/server/plugin"
+    log_level = "DEBUG"
+    umask = ""
+}
+
+plugins {
+    ControlPlaneCA "ca" {
+        plugin_cmd = "plugin/server/ca-memory"
+        plugin_checksum = ""
+        enabled = true
+        plugin_data {
+            trust_domain = "example.org",
+            key_size = 2048,
+            backdate_seconds = 1,
+            default_ttl = 3600,
+            cert_subject = {
+                Country = ["US"],
+                Organization = ["SPIFFE"],
+                CommonName = "",
+            }
+        }
+    }
+
+    DataStore "datastore" {
+        plugin_cmd = "plugin/server/datastore-sqlite"
+        plugin_checksum = ""
+        enabled = true
+        plugin_data {
+            file_name = "./.data/datastore.sqlite3"
+        }
+    }
+
+    NodeAttestor "join_token" {
+        plugin_cmd = "plugin/server/nodeattestor-jointoken"
+        plugin_checksum = ""
+        enabled = true
+        plugin_data {
+            trust_domain = "example.org"
+        }
+    }
+
+    NodeResolver "noop" {
+        plugin_cmd = "plugin/server/noderesolver-noop"
+        plugin_checksum = ""
+        enabled = true
+        plugin_data {}
+    }
+
+    UpstreamCA "upstream_ca" {
+        plugin_cmd = "plugin/server/upstreamca-memory"
+        plugin_checksum = ""
+        enabled = true
+        plugin_data {
+            trust_domain = "example.org"
+            ttl = "1h"
+            key_file_path = "conf/server/dummy_upstream_ca.key"
+            cert_file_path = "conf/server/dummy_upstream_ca.crt"
+        }
+    }
+}

--- a/vendor.sh
+++ b/vendor.sh
@@ -6,11 +6,6 @@ declare -r PCRE_VERSION="8.41"
 declare -r PCRE_URL="ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre-${PCRE_VERSION}.tar.gz"
 declare -r ZLIB_VERSION="1.2.11"
 declare -r ZLIB_URL="http://zlib.net/zlib-${ZLIB_VERSION}.tar.gz"
-declare -r GRPC_VERSION="v1.9.1"
-declare -r GRPC_URL="https://github.com/grpc/grpc"
-declare -r PROTOBUF_VERSION="3.5.1"
-declare -r PROTOBUF_URL="https://github.com/google/protobuf/archive/v${PROTOBUF_VERSION}.tar.gz"
-
 declare -r VENDOR_DIR="/tmp/vendor"
 
 set -e
@@ -50,33 +45,8 @@ do_openssl() {
 	)
 }
 
-do_grpc() {
-	(
-		cd ${VENDOR_DIR}
-		rm -rf grpc
-		git clone -b ${GRPC_VERSION} ${GRPC_URL}
-		cd grpc
-		git submodule update --init
-		make
-		make install
-	)
-}
-
-do_protobuf() {
-	untar_url ${PROTOBUF_URL}
-	(
-		cd ${VENDOR_DIR}/protobuf-${PROTOBUF_VERSION}
-		./autogen.sh
-		./configure
-		make
-		make install
-	)
-}
-
 mkdir -p ${VENDOR_DIR}
 do_pcre
 do_zlib
 do_openssl
-do_grpc
-do_protobuf
 rm -rf ${VENDOR_DIR}


### PR DESCRIPTION
- Add `ngx_http_fetch_spiffe_certs_module` nginx module to automatically fetch SVIDs.
- Include fixes to properly check SPIFFE ID of presented certificate.