### PR TITLE
Perform workload attestation of the worker process instead of the master process

### DIFF
--- a/spiffe-support/nginx_blog.conf
+++ b/spiffe-support/nginx_blog.conf
@@ -1,5 +1,6 @@
 daemon off;
-pid /certs/nginx.pid;
+user nginx-blog;
+pid /home/nginx-blog/nginx.pid;
 worker_processes 1;
 error_log /dev/stdout debug;
 events {

--- a/spiffe-support/nginx_fe.conf
+++ b/spiffe-support/nginx_fe.conf
@@ -1,4 +1,6 @@
 daemon off;
+user nginx-fe;
+pid /home/nginx-fe/nginx.pid;
 worker_processes 1;
 error_log /dev/stdout debug;
 events {

--- a/spiffe-support/src/http/modules/ngx_http_proxy_module.c
+++ b/spiffe-support/src/http/modules/ngx_http_proxy_module.c
@@ -4319,16 +4319,6 @@ ngx_http_proxy_set_ssl(ngx_conf_t *cf, ngx_http_proxy_loc_conf_t *plcf)
     // when it is enabled, configuration of file locations is avoided.
     //
     if (plcf->upstream.ssl_spiffe) {
-        if(create_spiffe_thread(plcf->upstream.ssl, 0, plcf->ssl_verify_depth)
-            != NGX_OK)
-        {
-            return NGX_ERROR;
-        }
-
-        while (is_certificates_updated() != NGX_OK) {
-            // just wait
-        }
-
         if (ngx_ssl_crl(cf, plcf->upstream.ssl, &plcf->ssl_crl) != NGX_OK) {
             return NGX_ERROR;
         }

--- a/spiffe-support/src/http/modules/ngx_http_ssl_module.c
+++ b/spiffe-support/src/http/modules/ngx_http_ssl_module.c
@@ -777,21 +777,6 @@ ngx_http_ssl_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
         return NGX_CONF_ERROR;
     }
 
-    // In case SPIFFE ID validation is enabled, create a thread to consume certificates and push them into SSL_CTX,
-    // when it is enabled, configuration of file locations is avoided.
-    //  
-    if (conf->ssl_spiffe) {
-        if(create_spiffe_thread(&conf->ssl, 1, conf->verify_depth)
-            != NGX_OK)
-        {
-            return NGX_CONF_ERROR;
-        }
-        while (is_certificates_updated() != NGX_OK) {
-            // just wait
-        }
-       
-    } 
-
     if (ngx_ssl_crl(cf, &conf->ssl, &conf->crl) != NGX_OK) {
         return NGX_CONF_ERROR;
     }

--- a/spiffe-support/src/http/modules/ngx_http_ssl_module.h
+++ b/spiffe-support/src/http/modules/ngx_http_ssl_module.h
@@ -64,7 +64,7 @@ typedef struct {
 
 
 extern ngx_module_t  ngx_http_ssl_module;
-ngx_int_t create_spiffe_thread(ngx_ssl_t *ssl, ngx_flag_t is_clientt, ngx_int_t depth);
+ngx_int_t create_spiffe_thread(ngx_ssl_t *ssl, ngx_flag_t is_client, ngx_int_t depth);
 ngx_int_t is_certificates_updated();
 
 #endif /* _NGX_HTTP_SSL_H_INCLUDED_ */


### PR DESCRIPTION
Change to perform workload attestation of the worker process instead of the master process.
Updated configuration files to use the `user` directive to show the ability of having attestation of the worker process.

This fixes #15.