### PR TITLE
Adding TCP support to spiffe-nginx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .cache
+.vscode/
 /nginx
 /nginx-*
 workload.grpc.pb.*

--- a/build.sh
+++ b/build.sh
@@ -46,6 +46,8 @@ case $1 in
 			--with-cc-opt="-fPIE" --with-ld-opt="-fpie -static" \
 			--with-debug \
 			--with-http_ssl_module \
+			--with-stream \
+			--with-stream_ssl_module \
 			--add-module=/opt/nginx-dev/ngx_http_fetch_spiffe_certs_module
 		set +x
 		update_nginx_modules

--- a/ngx_http_fetch_spiffe_certs_module/config
+++ b/ngx_http_fetch_spiffe_certs_module/config
@@ -1,6 +1,9 @@
 ngx_addon_name=ngx_http_fetch_spiffe_certs_module
 HTTP_MODULES="$HTTP_MODULES ngx_http_fetch_spiffe_certs_module"
+STREAM_MODULES="$STREAM_MODULES ngx_stream_fetch_spiffe_certs_module"
+NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_common_spiffe_module.cpp"
 NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_http_fetch_spiffe_certs_module.cpp"
+NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_stream_fetch_spiffe_certs_module.cpp"
 NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/c-spiffe.cc"
 NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/workload.pb.cc"
 NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/workload.grpc.pb.cc"

--- a/ngx_http_fetch_spiffe_certs_module/ngx_common_spiffe_module.cpp
+++ b/ngx_http_fetch_spiffe_certs_module/ngx_common_spiffe_module.cpp
@@ -1,0 +1,424 @@
+extern "C" {
+    #include <ngx_config.h>
+    #include <ngx_core.h>
+}
+
+#include <openssl/ssl.h>
+#include <openssl/rsa.h>
+#include <openssl/x509.h>
+#include <openssl/evp.h>
+
+#include "ngx_common_spiffe_module.h"
+
+static ngx_int_t ngx_ssl_spiffe_reload_certificates(ngx_ssl_t *ngx_ssl, std::string cert_der, std::string key_der, ngx_ssl_thread_config_t *config);
+static ngx_int_t ngx_ssl_spiffe_reload_client_certificates(ngx_ssl_t *ngx_ssl, std::string bundle_der, ngx_ssl_thread_config_t *config);
+static ngx_int_t ngx_ssl_spiffe_reload_trusted_certificates(ngx_ssl_t *ngx_ssl, std::string bundle_der, ngx_ssl_thread_config_t *config);
+
+static ngx_int_t ngx_ssl_spiffe_add_all_cas(ngx_ssl_t *ngx_ssl, std::string bundle_der, ngx_ssl_thread_config_t *config);
+static int xname_cmp(const X509_NAME * const *a, const X509_NAME * const *b);
+
+
+/**
+ * Reload certificate and key into SSL_CTX, use provided der and transform them into x509 and EVP_PKEY.
+ */
+static ngx_int_t
+ngx_ssl_spiffe_reload_certificates(ngx_ssl_t *ngx_ssl, std::string cert_der, std::string key_der, ngx_ssl_thread_config_t *config)
+{
+    X509        *x509;
+    EVP_PKEY *evp;
+    ngx_str_t   *pwd;
+    ngx_uint_t   tries;
+    ngx_ssl_t *ssl;
+    unsigned char *buf, *p;
+
+    spiffe_log(NGX_LOG_DEBUG, config->log, "reloading certificates");
+    // Set ssl with provided ngx_ssl
+    //
+    ssl = ngx_ssl;
+    
+    // Parse der to x509
+    //
+    int len = cert_der.size();
+    buf = (unsigned char *)cert_der.c_str();
+    p = buf;
+    x509 = d2i_X509(NULL, (const unsigned char**)&p, len);
+    if (x509 == NULL) {
+        spiffe_log(NGX_LOG_ERR, config->log, "could not extract certificate from svid");
+        
+        return NGX_ERROR;
+    }
+    
+    // Use provided x509 certificate.
+    //
+    if (SSL_CTX_use_certificate(ssl->ctx, x509) == 0) {     
+        spiffe_log(NGX_LOG_ERR, config->log, "SSL_CTX_use_certificate failed");
+                      
+        X509_free(x509);
+        return NGX_ERROR;
+    }
+
+    // Set certificate name.
+    //
+    ngx_str_t certificateName = ngx_string("SPIFFE SVID certificate");
+    if (X509_set_ex_data(x509, ngx_ssl_certificate_name_index, certificateName.data)
+        == 0)
+    {
+        spiffe_log(NGX_LOG_ERR, config->log, "X509_set_ex_data() failed");
+        
+        X509_free(x509);
+        return NGX_ERROR;
+    }
+
+    // Set next certificate 
+    //
+    if (X509_set_ex_data(x509, ngx_ssl_next_certificate_index,
+                      SSL_CTX_get_ex_data(ssl->ctx, ngx_ssl_certificate_index))
+        == 0)
+    { 
+        spiffe_log(NGX_LOG_ERR, config->log, "X509_set_ex_data() failed");
+        
+        X509_free(x509);
+        return NGX_ERROR;
+    }
+
+    // Set extra data for certificate
+    //
+    if (SSL_CTX_set_ex_data(ssl->ctx, ngx_ssl_certificate_index, x509)
+        == 0)
+    {
+        spiffe_log(NGX_LOG_ERR, config->log, "SSL_CTX_set_ex_data() failed");
+                     
+        X509_free(x509);
+        return NGX_ERROR;
+    }
+
+    tries = 1;
+#if (NGX_SUPPRESS_WARN)
+    pwd = NULL;
+#endif
+    
+    buf = (unsigned char *)key_der.c_str();
+    p = buf;
+    len = key_der.size();
+
+    for ( ;; ) {
+        spiffe_log(NGX_LOG_DEBUG, config->log, "reloading keys");
+
+        // Transform DER to EVP_KEY
+        //
+        evp =  d2i_AutoPrivateKey(NULL, (const unsigned char**)&p,
+                                len);
+        if (evp == NULL) {
+            spiffe_log(NGX_LOG_ERR, config->log, "could not extract evp key for");
+            return NGX_ERROR;
+        }
+        
+        if (SSL_CTX_use_PrivateKey(ssl->ctx, evp)
+            != 0)
+        {
+            break;
+        }
+
+        if (--tries) {
+            spiffe_log(NGX_LOG_ERR, config->log, "SSL_CTX_use_PrivateKey() failed, retrying");
+            ERR_clear_error();
+            SSL_CTX_set_default_passwd_cb_userdata(ssl->ctx, ++pwd);
+            continue;
+        }
+        spiffe_log(NGX_LOG_ERR, config->log, "SSL_CTX_use_PrivateKey() failed");
+                   
+        return NGX_ERROR;
+    }
+    
+    SSL_CTX_set_default_passwd_cb(ssl->ctx, NULL);
+
+    return NGX_OK;
+}
+
+/**
+ * verify_callback method, as nginx it's used only for debug porpuses.
+ */
+static int
+ngx_ssl_verify_callback(int ok, X509_STORE_CTX *x509_store)
+{
+    return 1;
+}
+
+/**
+ * Reload all client certificates into SSL_CTX using provided bundle_der.
+ */
+static ngx_int_t
+ngx_ssl_spiffe_reload_client_certificates(ngx_ssl_t *ngx_ssl, std::string bundle_der, ngx_ssl_thread_config_t *config)
+{ 
+    ngx_ssl_t *ssl;
+    X509_NAME *xn = NULL;
+    X509 *x509;
+    unsigned char *buf, *p;
+    STACK_OF(X509_NAME) *sk;
+
+    spiffe_log(NGX_LOG_DEBUG, config->log, "reloading client certificate");
+
+    ssl = ngx_ssl;
+    sk = sk_X509_NAME_new(xname_cmp);
+
+    // Set verify methods.
+    //
+    SSL_CTX_set_verify(ssl->ctx, SSL_VERIFY_PEER, ngx_ssl_verify_callback);
+    SSL_CTX_set_verify_depth(ssl->ctx, config->depth);
+
+    // Add all CAs into SSL_CTX
+    //
+	ngx_ssl_spiffe_add_all_cas(ssl, bundle_der, config);
+ 
+    int len = bundle_der.size();
+    buf = (unsigned char *)bundle_der.c_str();
+    p = buf;
+
+    // Extract all X509_NAME from certificates inside bundle der and push them into STACK_OF(X509_NAME)
+    //
+    while ((x509 = d2i_X509(NULL, (const unsigned char**)&p, len)) != NULL) {
+        if (x509 == NULL) {
+            spiffe_log(NGX_LOG_ERR, config->log, "d2i_X509 error. ");
+            X509_free(x509);    
+            return NGX_ERROR;
+        }
+        xn = X509_get_subject_name(x509);
+        if (sk_X509_NAME_find(sk, xn) >= 0) {
+			X509_NAME_free(xn);
+        }
+		else {
+			sk_X509_NAME_push(sk, xn);
+		}
+    }
+    X509_free(x509);
+
+    // Set all client CAs from STACK
+    //
+    SSL_CTX_set_client_CA_list(ssl->ctx, sk);
+    return NGX_OK;
+}
+
+/**
+ * Reload all trusted certificates into SSL_CTX using provided bundle_der.
+ */
+static ngx_int_t
+ngx_ssl_spiffe_reload_trusted_certificates(ngx_ssl_t *ngx_ssl, std::string bundle_der, ngx_ssl_thread_config_t *config)
+{
+    ngx_ssl_t *ssl;
+    ssl = ngx_ssl;
+    spiffe_log(NGX_LOG_DEBUG, config->log, "reloading trusted certificate");
+
+    // Set verify methods.
+    //
+    SSL_CTX_set_verify_depth(ssl->ctx, config->depth);
+    SSL_CTX_set_verify(ssl->ctx, SSL_VERIFY_PEER, ngx_ssl_verify_callback);
+    
+    // Add all CAs into SSL_CTX
+    //
+	ngx_ssl_spiffe_add_all_cas(ssl, bundle_der, config);
+
+    ERR_clear_error();
+
+    return NGX_OK;
+}
+
+/**
+ * Add all CA certificates from bundle_der into SSL_CTX
+ */
+static ngx_int_t
+ngx_ssl_spiffe_add_all_cas(ngx_ssl_t *ngx_ssl, std::string bundle_der, ngx_ssl_thread_config_t *config) {
+    ngx_ssl_t *ssl;
+    X509_STORE *store = NULL;
+    X509 *x509;
+    unsigned char *buf, *p;
+    
+    spiffe_log(NGX_LOG_DEBUG, config->log, "adding certificates from bundle");
+    ssl = ngx_ssl;
+
+    int len = bundle_der.size();
+    buf = (unsigned char *)bundle_der.c_str();
+    p = buf;
+   
+    // Get certificate store, to push all CAs.
+    //
+    store = SSL_CTX_get_cert_store(ssl->ctx);
+    
+    if(!store) {
+        spiffe_log(NGX_LOG_ERR, config->log, "could not get cert store");    
+        return NGX_ERROR;
+    }
+
+    // Consume all certificates into bundle and push inside X509_STORE
+    //
+    while ((x509 = d2i_X509(NULL, (const unsigned char**)&p, len)) != NULL) {
+        if (x509 == NULL) {
+            spiffe_log(NGX_LOG_ERR, config->log, "d2i_X509 error");
+            X509_free(x509);    
+            return NGX_ERROR;
+        }
+
+        if(!X509_STORE_add_cert(store, x509)) {
+            auto error = ERR_get_error();
+            // Check for duplicate root certificate
+            if (ERR_GET_REASON(error) != X509_R_CERT_ALREADY_IN_HASH_TABLE) {
+                spiffe_log(NGX_LOG_ERR, config->log, "could not add root certificate to ssl context");
+            X509_free(x509);
+            return NGX_ERROR;
+            }
+        }
+        X509_free(x509);
+    }
+
+    return NGX_OK;
+}
+
+/**
+ * Compare provided X509_NAMEs.
+ */
+static int
+xname_cmp(const X509_NAME * const *a, const X509_NAME * const *b)
+{
+	return (X509_NAME_cmp(*a, *b));
+}
+
+/** 
+ * Log message into stderr configured for nginx
+ */
+void spiffe_log(ngx_uint_t log_level, ngx_log_t *log, std::string message)
+{
+    spiffe_log(log_level, log, message, "");
+}
+
+/**
+ * Log message into stderr configured for nginx
+ */
+void spiffe_log(ngx_uint_t log_level, ngx_log_t *log, std::string message, std::string arg)
+{
+    if(!log) {
+        return;
+    }
+
+    if (log_level > log->log_level) {
+        return;
+    }
+    static const char *severities[] = {"stderr", "emerg", "alert", "crit",
+        "error", "warn", "notice", "info", "debug", NULL};
+
+    time_t ctt = time(0);
+    char now[30];
+    strftime(now, 30, "%Y/%m/%d %H:%M:%S", localtime(&ctt));
+fprintf(stderr, "%s [spiffe-%s] %i: %s %s \n", now, severities[log_level], getpid(), message.c_str(), arg.c_str());
+}
+
+/**
+ * Update ssl context in provided config using GRPC response. 
+ */
+void svid_updated_callback(X509SVIDResponse x509SVIDResponse, ngx_ssl_thread_config_t *config) {
+    spiffe_log(NGX_LOG_DEBUG, config->log, "fetched X509SVID with SPIFFE ID: ", x509SVIDResponse.svids(0).spiffe_id());
+    config->svids_updated = false;
+
+    // Successfull response received. Reset delay
+    config->retry_delay_svids = INITIAL_DELAY;
+
+    ngx_ssl_t *ngx_ssl = *config->ngx_ssl;
+
+    int svids_size = x509SVIDResponse.svids_size();
+    
+    if (svids_size < 1) {
+        spiffe_log(NGX_LOG_ERR, config->log, "no SVID was returned");
+    }
+
+    if (svids_size > 1) {
+        spiffe_log(NGX_LOG_WARN, config->log, "only first SVID will be used from multiple svids returned");
+    }
+
+    // reload certificate and key into SSL_CTX
+    ngx_ssl_spiffe_reload_certificates(ngx_ssl, x509SVIDResponse.svids(0).x509_svid(), x509SVIDResponse.svids(0).x509_svid_key(), config);
+
+    // Concatenate all bundles into a single bundle
+    ::std::string bundle = get_bundle(x509SVIDResponse, config);
+   
+    // reload trusted or client certificate into SSL_CTX
+    if (config->is_client_certificate) {
+        ngx_ssl_spiffe_reload_client_certificates(ngx_ssl,  bundle, config);
+    } else {
+        ngx_ssl_spiffe_reload_trusted_certificates(ngx_ssl, bundle, config);
+    }
+
+    config->svids_updated = true; 
+}
+
+/**
+ * Fetch svids calling the Workload API.
+ */
+void fetch_svids(ngx_ssl_t *ssl, ngx_ssl_thread_config_t *config, spiffe::WorkloadAPIClient *workloadClient, ngx_str_t *ssl_spiffe_sock) {
+    spiffe_log(NGX_LOG_DEBUG, config->log, "fetching SVIDs");
+   
+    // update thread config with provided ssl
+    config->ngx_ssl = &ssl;
+    
+    config->retry_delay_svids = INITIAL_DELAY;
+    
+    std::string socket_address = (const char*)ssl_spiffe_sock->data;
+    std::string const SOCKET_PATH_ERR = "Invalid socket path for Workload API endpoint: ";
+    if (socket_address.length() == 0) {
+        spiffe_log(NGX_LOG_ERR, config->log, SOCKET_PATH_ERR, "empty path");
+        return;
+    }
+
+    if (socket_address.at(0) != '/') {
+        spiffe_log(NGX_LOG_ERR, config->log, SOCKET_PATH_ERR, "path not absolute");
+        return;
+    }    
+    workloadClient->SetSocketAddress("unix:" + socket_address);
+
+    Start:
+    workloadClient->FetchX509SVIDs();
+    if (!workloadClient->GetFetchX509SVIDsStatus().ok()) {
+        std::stringstream msg;
+        msg << "FetchX509SVID rpc failed. Error code: " <<
+            workloadClient->GetFetchX509SVIDsStatus().error_code() <<
+            ". Error message: " <<
+            workloadClient->GetFetchX509SVIDsStatus().error_message();
+        spiffe_log(NGX_LOG_ERR, config->log, msg.str());
+        usleep(config->retry_delay_svids);
+        config->retry_delay_svids += config->retry_delay_svids;
+        if (config->retry_delay_svids > MAX_DELAY) {
+            config->retry_delay_svids = MAX_DELAY;
+        }
+        goto Start;
+    }
+}
+
+/**
+ * Get a bundle that contains svid's bundle and all federated bundles that svid is federated with.
+ */
+::std::string get_bundle(X509SVIDResponse x509SVIDResponse, ngx_ssl_thread_config_t *config) {
+    ::std::string bundle = "";
+    ::std::string federatedBundle = "";
+    ::google::protobuf::Map< ::std::string, ::std::string >::iterator it;
+
+    ::google::protobuf::Map< ::std::string, ::std::string > federatedBundles = x509SVIDResponse.federated_bundles();
+    ::X509SVID svid = x509SVIDResponse.svids(0);
+
+    // Add svid bundle
+    bundle += svid.bundle();
+
+    // Iterate federateds with vector and add bundles to returned bundle.
+    for (std::string federated : svid.federates_with()) {
+        it = federatedBundles.find(federated);
+        
+        std::stringstream searchingMsg;
+        searchingMsg << "searching federated bundle " << federated;
+        spiffe_log(NGX_LOG_DEBUG, config->log, searchingMsg.str());
+
+        if (it == federatedBundles.end()) {
+            std::stringstream msg;
+            msg << "federated bundle " << federated << " does not exist ";
+            spiffe_log(NGX_LOG_WARN, config->log, msg.str());
+            continue;
+        } 
+        bundle += it->second;
+    }
+    return bundle;
+}

--- a/ngx_http_fetch_spiffe_certs_module/ngx_common_spiffe_module.cpp
+++ b/ngx_http_fetch_spiffe_certs_module/ngx_common_spiffe_module.cpp
@@ -168,7 +168,7 @@ ngx_ssl_spiffe_reload_client_certificates(ngx_ssl_t *ngx_ssl, std::string bundle
 
     // Add all CAs into SSL_CTX
     //
-	ngx_ssl_spiffe_add_all_cas(ssl, bundle_der, config);
+    ngx_ssl_spiffe_add_all_cas(ssl, bundle_der, config);
  
     int len = bundle_der.size();
     buf = (unsigned char *)bundle_der.c_str();
@@ -215,7 +215,7 @@ ngx_ssl_spiffe_reload_trusted_certificates(ngx_ssl_t *ngx_ssl, std::string bundl
     
     // Add all CAs into SSL_CTX
     //
-	ngx_ssl_spiffe_add_all_cas(ssl, bundle_der, config);
+    ngx_ssl_spiffe_add_all_cas(ssl, bundle_der, config);
 
     ERR_clear_error();
 

--- a/ngx_http_fetch_spiffe_certs_module/ngx_common_spiffe_module.h
+++ b/ngx_http_fetch_spiffe_certs_module/ngx_common_spiffe_module.h
@@ -1,0 +1,26 @@
+#ifndef __NGX_COMMON_SPIFFE_H_INCLUDED__
+#define __NGX_COMMON_SPIFFE_H_INCLUDED__
+
+#define INITIAL_DELAY 1000000 // microseconds
+#define MAX_DELAY INITIAL_DELAY * 60
+
+#include <string>
+#include <sstream>
+#include "c-spiffe.h"
+
+typedef struct {
+    ngx_ssl_t   **ngx_ssl;
+    bool is_client_certificate = false;
+    ngx_int_t depth;
+    bool svids_updated = false;
+    useconds_t retry_delay_svids = INITIAL_DELAY;
+    ngx_log_t *log;
+} ngx_ssl_thread_config_t;
+
+void spiffe_log(ngx_uint_t log_level, ngx_log_t *log, std::string message);
+void spiffe_log(ngx_uint_t log_level, ngx_log_t *log, std::string message, std::string arg);
+void svid_updated_callback(X509SVIDResponse x509SVIDResponse, ngx_ssl_thread_config_t *config);
+void fetch_svids(ngx_ssl_t *ssl, ngx_ssl_thread_config_t *config, spiffe::WorkloadAPIClient *workloadClient, ngx_str_t *ssl_spiffe_sock);
+::std::string get_bundle(X509SVIDResponse x509SVIDResponse, ngx_ssl_thread_config_t *config);
+
+#endif // __NGX_COMMON_SPIFFE_H_INCLUDED__

--- a/ngx_http_fetch_spiffe_certs_module/ngx_stream_fetch_spiffe_certs_module.cpp
+++ b/ngx_http_fetch_spiffe_certs_module/ngx_stream_fetch_spiffe_certs_module.cpp
@@ -1,0 +1,118 @@
+extern "C" {
+    #include <ngx_config.h>
+    #include <ngx_core.h>
+    #include <ngx_stream.h>
+}
+
+#include <thread>
+
+#include "c-spiffe.h"
+#include "ngx_common_spiffe_module.h"
+
+void svid_stream_updated_callback(X509SVIDResponse x509SVIDResponse);
+
+spiffe::WorkloadAPIClient workloadClient_stream(svid_stream_updated_callback);
+
+extern "C" ngx_int_t create_stream_spiffe_thread(ngx_ssl_t *ssl, ngx_flag_t is_client, ngx_int_t depth);
+extern "C" ngx_int_t is_stream_certificates_updated();
+
+static ngx_ssl_thread_config_t ngx_stream_ssl_thread_config;
+
+typedef struct {
+    ngx_str_t ssl_spiffe_sock;
+} ngx_stream_fetch_spiffe_certs_srv_conf_t;
+
+ngx_stream_fetch_spiffe_certs_srv_conf_t stream_configuration;
+
+static ngx_command_t ngx_stream_fetch_spiffe_certs_commands[] = {
+    { ngx_string("ssl_spiffe_sock"),
+        NGX_STREAM_MAIN_CONF|NGX_STREAM_SRV_CONF|NGX_CONF_TAKE1,
+        ngx_conf_set_str_slot,
+        NGX_STREAM_SRV_CONF_OFFSET,
+        offsetof(ngx_stream_fetch_spiffe_certs_srv_conf_t, ssl_spiffe_sock),
+        NULL },
+      ngx_null_command
+};
+
+static void * ngx_stream_fetch_spiffe_certs_create_conf(ngx_conf_t *cf)
+{
+    ngx_stream_fetch_spiffe_certs_srv_conf_t  *scf;
+    scf = (ngx_stream_fetch_spiffe_certs_srv_conf_t*)ngx_pcalloc(cf->pool, sizeof(ngx_stream_fetch_spiffe_certs_srv_conf_t));
+    return scf;
+}
+
+void svid_stream_updated_callback(X509SVIDResponse x509SVIDResponse) {
+    svid_updated_callback(x509SVIDResponse, &ngx_stream_ssl_thread_config);
+}
+
+void fetch_stream_svids(ngx_ssl_t *ssl) {
+    fetch_svids(ssl, &ngx_stream_ssl_thread_config, &workloadClient_stream, &stream_configuration.ssl_spiffe_sock);
+}
+
+/**
+ * return NGX_OK in case certificate was reloaded into SSL_CTX.
+ */
+ngx_int_t is_stream_certificates_updated() {
+    if (ngx_stream_ssl_thread_config.svids_updated) {
+        return NGX_OK;
+    }
+
+    return NGX_AGAIN;
+}
+
+/**
+ *  Create a thread to automatically consume gRPC and load certificates into SSL_CTX
+ */
+ngx_int_t create_stream_spiffe_thread(ngx_ssl_t *ssl, ngx_flag_t is_client, ngx_int_t depth) {
+    spiffe_log(NGX_LOG_INFO, ngx_stream_ssl_thread_config.log, "creating threads to fetch updates from SPIFFE Workload API");
+
+    ngx_stream_ssl_thread_config.svids_updated = false;
+    ngx_stream_ssl_thread_config.is_client_certificate = (is_client == 1);
+    ngx_stream_ssl_thread_config.depth = depth;
+
+    std::thread fetch_svids_thread(fetch_stream_svids, ssl);
+    fetch_svids_thread.detach();
+
+    return NGX_OK;
+}
+
+static char * ngx_stream_fetch_spiffe_certs_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
+{
+    ngx_stream_fetch_spiffe_certs_srv_conf_t *prev = (ngx_stream_fetch_spiffe_certs_srv_conf_t*)parent;
+    ngx_stream_fetch_spiffe_certs_srv_conf_t *conf = (ngx_stream_fetch_spiffe_certs_srv_conf_t*)child;
+
+    ngx_stream_ssl_thread_config.log = &cf->cycle->new_log;
+
+    ngx_conf_merge_str_value(conf->ssl_spiffe_sock, prev->ssl_spiffe_sock, "");
+    
+    if (conf->ssl_spiffe_sock.len < 1) {
+        spiffe_log(NGX_LOG_ERR, ngx_stream_ssl_thread_config.log, "ssl_spiffe_sock was no provided.");
+    }
+    stream_configuration.ssl_spiffe_sock = conf->ssl_spiffe_sock;
+    
+    return NGX_CONF_OK;
+}
+
+static ngx_stream_module_t ngx_stream_fetch_spiffe_certs_module_ctx = {
+    NULL,                                       /* preconfiguration */
+    NULL,                                       /* postconfiguration */
+    NULL,                                       /* create main configuration */
+    NULL,                                       /* init main configuration */
+    ngx_stream_fetch_spiffe_certs_create_conf,    /* create server configuration */
+    ngx_stream_fetch_spiffe_certs_merge_srv_conf, /* merge server configuration */
+};
+
+ngx_module_t ngx_stream_fetch_spiffe_certs_module = {
+    NGX_MODULE_V1,
+    &ngx_stream_fetch_spiffe_certs_module_ctx,  /* module context */
+    ngx_stream_fetch_spiffe_certs_commands,     /* module directives */
+    NGX_STREAM_MODULE,                          /* module type */
+    NULL,                                     /* init master */
+    NULL,                                     /* init module */
+    NULL,                                     /* init process */
+    NULL,                                     /* init thread */
+    NULL,                                     /* exit thread */
+    NULL,                                     /* exit process */
+    NULL,                                     /* exit master */
+    NGX_MODULE_V1_PADDING
+};

--- a/spiffe-support/nginx_tcp_backend.conf
+++ b/spiffe-support/nginx_tcp_backend.conf
@@ -1,0 +1,36 @@
+# For docker use daemon MUST be 'off'.
+daemon on;
+pid /certs/nginx.pid;
+worker_processes 1;
+error_log /dev/stdout debug;
+events {
+  worker_connections 1024;
+}
+
+stream {
+   proxy_timeout 10000d;
+
+   upstream local_workload {
+    # Upstream workload location. Configure this to adjust the location and port that the local workload will be listening to upstream traffic from
+    server 127.0.0.1:3306;
+  }
+  server {
+    listen                9001 ssl;
+    
+    # Socket path of Spire Agent
+    ssl_spiffe_sock       /tmp/agent.sock;
+    
+    # Required to enable ssl
+    ssl_verify_client on;
+
+    # Enable or disable to consume generated Spiffe certificates and perform SPIFFE ID validation     
+    # of the clients TCP servers, based on the proxy_ssl_spiffe_accept list.
+    ssl_spiffe on;
+    ssl_spiffe_accept spiffe://example.org/host/frontend;
+
+    proxy_pass            local_workload;
+
+    ssl_handshake_timeout 30s;
+  }
+}
+

--- a/spiffe-support/nginx_tcp_frontend.conf
+++ b/spiffe-support/nginx_tcp_frontend.conf
@@ -1,0 +1,29 @@
+# For docker use daemon MUST be 'off'.
+daemon on;
+worker_processes 1;
+error_log /dev/stdout debug;
+events {
+  worker_connections 1024;
+}
+
+stream {
+  proxy_timeout 10000d;
+  server {
+    listen      9000;
+
+    # Socket path of Spire Agent
+    ssl_spiffe_sock       /tmp/agent.sock;
+    
+    # required to enable proxy ssl
+    proxy_ssl  on;
+    proxy_ssl_verify        on;
+
+    # Enable or disable to consume generated Spiffe certificates and perform SPIFFE ID validation 
+    # of the proxied TCP server, based on the proxy_ssl_spiffe_accept list.
+    proxy_ssl_spiffe on;
+    proxy_ssl_spiffe_accept spiffe://example.org/host/blog;
+
+    proxy_pass 127.0.0.1:9001;
+  }
+}
+

--- a/spiffe-support/src/event/ngx_event_openssl.h
+++ b/spiffe-support/src/event/ngx_event_openssl.h
@@ -200,6 +200,13 @@ ngx_int_t ngx_ssl_check_spiffe_id(ngx_connection_t *c, ngx_array_t *accepted);
 char *ngx_conf_set_spiffe_accept_slot(ngx_conf_t *cf, 
     ngx_command_t *cmd, void *conf);
 
+/*
+Given a spiffe ID and a list of accepted spiffe IDs, it will return:
+    1 if the specified ID is in the list
+    0 if the specified ID is not in the list
+*/
+ngx_flag_t ngx_is_spiffe_id_accepted(unsigned char *spiffe_id, ngx_array_t *accepted);
+
 ngx_int_t ngx_ssl_get_protocol(ngx_connection_t *c, ngx_pool_t *pool,
     ngx_str_t *s);
 ngx_int_t ngx_ssl_get_cipher_name(ngx_connection_t *c, ngx_pool_t *pool,

--- a/spiffe-support/src/http/ngx_http_request.c
+++ b/spiffe-support/src/http/ngx_http_request.c
@@ -1941,26 +1941,14 @@ ngx_http_process_request(ngx_http_request_t *r)
                     ASN1_STRING             *str;
                     GENERAL_NAME            *sanName;
                     STACK_OF(GENERAL_NAME)  *san_names = NULL;
-                    ngx_str_t               *accepted_elts;
-                    ngx_uint_t              i, found;
 
                     san_names = X509_get_ext_d2i((X509 *) cert, NID_subject_alt_name, NULL, NULL);
                     sanName = sk_GENERAL_NAME_value(san_names, 0); 
                     str = sanName->d.dNSName;
     
-                    accepted_elts = sscf->ssl_spiffe_accept->elts;
-
-                    found = 0;
                     // Vefify that the SPIFFE ID is in the accepted list
                     //
-                    for (i = 0; i < sscf->ssl_spiffe_accept->nelts; i++) {        
-                        if (ngx_strcmp(str->data, accepted_elts[i].data) == 0) {
-                            found = 1;
-                        
-                        }
-                    }
-
-                    if (found != 1 ) {
+                    if (!ngx_is_spiffe_id_accepted(str->data, sscf->ssl_spiffe_accept)) {
                         ngx_log_error(NGX_LOG_INFO, c->log, 0,
                                     "SPIFFE ID is not allowed: \"%s\",", str->data);
 

--- a/spiffe-support/src/stream/ngx_stream_proxy_module.c
+++ b/spiffe-support/src/stream/ngx_stream_proxy_module.c
@@ -1,0 +1,2234 @@
+
+/*
+ * Copyright (C) Roman Arutyunyan
+ * Copyright (C) Nginx, Inc.
+ */
+
+
+#include <ngx_config.h>
+#include <ngx_core.h>
+#include <ngx_stream.h>
+
+
+typedef struct {
+    ngx_addr_t                      *addr;
+    ngx_stream_complex_value_t      *value;
+#if (NGX_HAVE_TRANSPARENT_PROXY)
+    ngx_uint_t                       transparent; /* unsigned  transparent:1; */
+#endif
+} ngx_stream_upstream_local_t;
+
+
+typedef struct {
+    ngx_msec_t                       connect_timeout;
+    ngx_msec_t                       timeout;
+    ngx_msec_t                       next_upstream_timeout;
+    size_t                           buffer_size;
+    size_t                           upload_rate;
+    size_t                           download_rate;
+    ngx_uint_t                       responses;
+    ngx_uint_t                       next_upstream_tries;
+    ngx_flag_t                       next_upstream;
+    ngx_flag_t                       proxy_protocol;
+    ngx_stream_upstream_local_t     *local;
+
+#if (NGX_STREAM_SSL)
+    ngx_flag_t                       ssl_enable;
+    ngx_flag_t                       ssl_session_reuse;
+    ngx_uint_t                       ssl_protocols;
+    ngx_str_t                        ssl_ciphers;
+    ngx_stream_complex_value_t      *ssl_name;
+    ngx_flag_t                       ssl_server_name;
+
+    ngx_flag_t                       ssl_verify;
+    ngx_uint_t                       ssl_verify_depth;
+    ngx_str_t                        ssl_trusted_certificate;
+    ngx_str_t                        ssl_crl;
+    ngx_str_t                        ssl_certificate;
+    ngx_str_t                        ssl_certificate_key;
+    ngx_flag_t                       ssl_spiffe;
+    ngx_array_t                     *ssl_spiffe_accept;
+    ngx_array_t                     *ssl_passwords;
+
+    ngx_ssl_t                       *ssl;
+#endif
+
+    ngx_stream_upstream_srv_conf_t  *upstream;
+    ngx_stream_complex_value_t      *upstream_value;
+} ngx_stream_proxy_srv_conf_t;
+
+
+static void ngx_stream_proxy_handler(ngx_stream_session_t *s);
+static ngx_int_t ngx_stream_proxy_eval(ngx_stream_session_t *s,
+    ngx_stream_proxy_srv_conf_t *pscf);
+static ngx_int_t ngx_stream_proxy_set_local(ngx_stream_session_t *s,
+    ngx_stream_upstream_t *u, ngx_stream_upstream_local_t *local);
+static void ngx_stream_proxy_connect(ngx_stream_session_t *s);
+static void ngx_stream_proxy_init_upstream(ngx_stream_session_t *s);
+static void ngx_stream_proxy_resolve_handler(ngx_resolver_ctx_t *ctx);
+static void ngx_stream_proxy_upstream_handler(ngx_event_t *ev);
+static void ngx_stream_proxy_downstream_handler(ngx_event_t *ev);
+static void ngx_stream_proxy_process_connection(ngx_event_t *ev,
+    ngx_uint_t from_upstream);
+static void ngx_stream_proxy_connect_handler(ngx_event_t *ev);
+static ngx_int_t ngx_stream_proxy_test_connect(ngx_connection_t *c);
+static void ngx_stream_proxy_process(ngx_stream_session_t *s,
+    ngx_uint_t from_upstream, ngx_uint_t do_write);
+static void ngx_stream_proxy_next_upstream(ngx_stream_session_t *s);
+static void ngx_stream_proxy_finalize(ngx_stream_session_t *s, ngx_uint_t rc);
+static u_char *ngx_stream_proxy_log_error(ngx_log_t *log, u_char *buf,
+    size_t len);
+
+static void *ngx_stream_proxy_create_srv_conf(ngx_conf_t *cf);
+static char *ngx_stream_proxy_merge_srv_conf(ngx_conf_t *cf, void *parent,
+    void *child);
+static char *ngx_stream_proxy_pass(ngx_conf_t *cf, ngx_command_t *cmd,
+    void *conf);
+static char *ngx_stream_proxy_bind(ngx_conf_t *cf, ngx_command_t *cmd,
+    void *conf);
+
+#if (NGX_STREAM_SSL)
+
+static ngx_int_t ngx_stream_proxy_send_proxy_protocol(ngx_stream_session_t *s);
+static char *ngx_stream_proxy_ssl_password_file(ngx_conf_t *cf,
+    ngx_command_t *cmd, void *conf);
+static void ngx_stream_proxy_ssl_init_connection(ngx_stream_session_t *s);
+static void ngx_stream_proxy_ssl_handshake(ngx_connection_t *pc);
+static ngx_int_t ngx_stream_proxy_ssl_name(ngx_stream_session_t *s);
+static ngx_int_t ngx_stream_proxy_set_ssl(ngx_conf_t *cf,
+    ngx_stream_proxy_srv_conf_t *pscf);
+
+static int spiffe_thread_created = 0;
+
+static ngx_conf_bitmask_t  ngx_stream_proxy_ssl_protocols[] = {
+    { ngx_string("SSLv2"), NGX_SSL_SSLv2 },
+    { ngx_string("SSLv3"), NGX_SSL_SSLv3 },
+    { ngx_string("TLSv1"), NGX_SSL_TLSv1 },
+    { ngx_string("TLSv1.1"), NGX_SSL_TLSv1_1 },
+    { ngx_string("TLSv1.2"), NGX_SSL_TLSv1_2 },
+    { ngx_string("TLSv1.3"), NGX_SSL_TLSv1_3 },
+    { ngx_null_string, 0 }
+};
+
+#endif
+
+
+static ngx_conf_deprecated_t  ngx_conf_deprecated_proxy_downstream_buffer = {
+    ngx_conf_deprecated, "proxy_downstream_buffer", "proxy_buffer_size"
+};
+
+static ngx_conf_deprecated_t  ngx_conf_deprecated_proxy_upstream_buffer = {
+    ngx_conf_deprecated, "proxy_upstream_buffer", "proxy_buffer_size"
+};
+
+
+static ngx_command_t  ngx_stream_proxy_commands[] = {
+
+    { ngx_string("proxy_pass"),
+      NGX_STREAM_SRV_CONF|NGX_CONF_TAKE1,
+      ngx_stream_proxy_pass,
+      NGX_STREAM_SRV_CONF_OFFSET,
+      0,
+      NULL },
+
+    { ngx_string("proxy_bind"),
+      NGX_STREAM_MAIN_CONF|NGX_STREAM_SRV_CONF|NGX_CONF_TAKE12,
+      ngx_stream_proxy_bind,
+      NGX_STREAM_SRV_CONF_OFFSET,
+      0,
+      NULL },
+
+    { ngx_string("proxy_connect_timeout"),
+      NGX_STREAM_MAIN_CONF|NGX_STREAM_SRV_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_msec_slot,
+      NGX_STREAM_SRV_CONF_OFFSET,
+      offsetof(ngx_stream_proxy_srv_conf_t, connect_timeout),
+      NULL },
+
+    { ngx_string("proxy_timeout"),
+      NGX_STREAM_MAIN_CONF|NGX_STREAM_SRV_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_msec_slot,
+      NGX_STREAM_SRV_CONF_OFFSET,
+      offsetof(ngx_stream_proxy_srv_conf_t, timeout),
+      NULL },
+
+    { ngx_string("proxy_buffer_size"),
+      NGX_STREAM_MAIN_CONF|NGX_STREAM_SRV_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_size_slot,
+      NGX_STREAM_SRV_CONF_OFFSET,
+      offsetof(ngx_stream_proxy_srv_conf_t, buffer_size),
+      NULL },
+
+    { ngx_string("proxy_downstream_buffer"),
+      NGX_STREAM_MAIN_CONF|NGX_STREAM_SRV_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_size_slot,
+      NGX_STREAM_SRV_CONF_OFFSET,
+      offsetof(ngx_stream_proxy_srv_conf_t, buffer_size),
+      &ngx_conf_deprecated_proxy_downstream_buffer },
+
+    { ngx_string("proxy_upstream_buffer"),
+      NGX_STREAM_MAIN_CONF|NGX_STREAM_SRV_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_size_slot,
+      NGX_STREAM_SRV_CONF_OFFSET,
+      offsetof(ngx_stream_proxy_srv_conf_t, buffer_size),
+      &ngx_conf_deprecated_proxy_upstream_buffer },
+
+    { ngx_string("proxy_upload_rate"),
+      NGX_STREAM_MAIN_CONF|NGX_STREAM_SRV_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_size_slot,
+      NGX_STREAM_SRV_CONF_OFFSET,
+      offsetof(ngx_stream_proxy_srv_conf_t, upload_rate),
+      NULL },
+
+    { ngx_string("proxy_download_rate"),
+      NGX_STREAM_MAIN_CONF|NGX_STREAM_SRV_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_size_slot,
+      NGX_STREAM_SRV_CONF_OFFSET,
+      offsetof(ngx_stream_proxy_srv_conf_t, download_rate),
+      NULL },
+
+    { ngx_string("proxy_responses"),
+      NGX_STREAM_MAIN_CONF|NGX_STREAM_SRV_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_num_slot,
+      NGX_STREAM_SRV_CONF_OFFSET,
+      offsetof(ngx_stream_proxy_srv_conf_t, responses),
+      NULL },
+
+    { ngx_string("proxy_next_upstream"),
+      NGX_STREAM_MAIN_CONF|NGX_STREAM_SRV_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot,
+      NGX_STREAM_SRV_CONF_OFFSET,
+      offsetof(ngx_stream_proxy_srv_conf_t, next_upstream),
+      NULL },
+
+    { ngx_string("proxy_next_upstream_tries"),
+      NGX_STREAM_MAIN_CONF|NGX_STREAM_SRV_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_num_slot,
+      NGX_STREAM_SRV_CONF_OFFSET,
+      offsetof(ngx_stream_proxy_srv_conf_t, next_upstream_tries),
+      NULL },
+
+    { ngx_string("proxy_next_upstream_timeout"),
+      NGX_STREAM_MAIN_CONF|NGX_STREAM_SRV_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_msec_slot,
+      NGX_STREAM_SRV_CONF_OFFSET,
+      offsetof(ngx_stream_proxy_srv_conf_t, next_upstream_timeout),
+      NULL },
+
+    { ngx_string("proxy_protocol"),
+      NGX_STREAM_MAIN_CONF|NGX_STREAM_SRV_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot,
+      NGX_STREAM_SRV_CONF_OFFSET,
+      offsetof(ngx_stream_proxy_srv_conf_t, proxy_protocol),
+      NULL },
+
+#if (NGX_STREAM_SSL)
+
+    { ngx_string("proxy_ssl"),
+      NGX_STREAM_MAIN_CONF|NGX_STREAM_SRV_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot,
+      NGX_STREAM_SRV_CONF_OFFSET,
+      offsetof(ngx_stream_proxy_srv_conf_t, ssl_enable),
+      NULL },
+
+    { ngx_string("proxy_ssl_session_reuse"),
+      NGX_STREAM_MAIN_CONF|NGX_STREAM_SRV_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot,
+      NGX_STREAM_SRV_CONF_OFFSET,
+      offsetof(ngx_stream_proxy_srv_conf_t, ssl_session_reuse),
+      NULL },
+
+    { ngx_string("proxy_ssl_protocols"),
+      NGX_STREAM_MAIN_CONF|NGX_STREAM_SRV_CONF|NGX_CONF_1MORE,
+      ngx_conf_set_bitmask_slot,
+      NGX_STREAM_SRV_CONF_OFFSET,
+      offsetof(ngx_stream_proxy_srv_conf_t, ssl_protocols),
+      &ngx_stream_proxy_ssl_protocols },
+
+    { ngx_string("proxy_ssl_ciphers"),
+      NGX_STREAM_MAIN_CONF|NGX_STREAM_SRV_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_str_slot,
+      NGX_STREAM_SRV_CONF_OFFSET,
+      offsetof(ngx_stream_proxy_srv_conf_t, ssl_ciphers),
+      NULL },
+
+    { ngx_string("proxy_ssl_name"),
+      NGX_STREAM_MAIN_CONF|NGX_STREAM_SRV_CONF|NGX_CONF_TAKE1,
+      ngx_stream_set_complex_value_slot,
+      NGX_STREAM_SRV_CONF_OFFSET,
+      offsetof(ngx_stream_proxy_srv_conf_t, ssl_name),
+      NULL },
+
+    { ngx_string("proxy_ssl_server_name"),
+      NGX_STREAM_MAIN_CONF|NGX_STREAM_SRV_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot,
+      NGX_STREAM_SRV_CONF_OFFSET,
+      offsetof(ngx_stream_proxy_srv_conf_t, ssl_server_name),
+      NULL },
+
+    { ngx_string("proxy_ssl_verify"),
+      NGX_STREAM_MAIN_CONF|NGX_STREAM_SRV_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot,
+      NGX_STREAM_SRV_CONF_OFFSET,
+      offsetof(ngx_stream_proxy_srv_conf_t, ssl_verify),
+      NULL },
+
+    { ngx_string("proxy_ssl_spiffe"),
+      NGX_STREAM_MAIN_CONF|NGX_STREAM_SRV_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot,
+      NGX_STREAM_SRV_CONF_OFFSET,
+      offsetof(ngx_stream_proxy_srv_conf_t, ssl_spiffe),
+      NULL }, 
+
+    { ngx_string("proxy_ssl_spiffe_accept"),
+      NGX_STREAM_MAIN_CONF|NGX_STREAM_SRV_CONF|(NGX_CONF_TAKE1|NGX_CONF_TAKE2|NGX_CONF_TAKE3   \
+              |NGX_CONF_TAKE4|NGX_CONF_TAKE5|NGX_CONF_TAKE6|NGX_CONF_TAKE7),
+      ngx_conf_set_spiffe_accept_slot,
+      NGX_STREAM_SRV_CONF_OFFSET,
+      offsetof(ngx_stream_proxy_srv_conf_t, ssl_spiffe_accept),
+      NULL },
+
+    { ngx_string("proxy_ssl_verify_depth"),
+      NGX_STREAM_MAIN_CONF|NGX_STREAM_SRV_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_num_slot,
+      NGX_STREAM_SRV_CONF_OFFSET,
+      offsetof(ngx_stream_proxy_srv_conf_t, ssl_verify_depth),
+      NULL },
+
+    { ngx_string("proxy_ssl_trusted_certificate"),
+      NGX_STREAM_MAIN_CONF|NGX_STREAM_SRV_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_str_slot,
+      NGX_STREAM_SRV_CONF_OFFSET,
+      offsetof(ngx_stream_proxy_srv_conf_t, ssl_trusted_certificate),
+      NULL },
+
+    { ngx_string("proxy_ssl_crl"),
+      NGX_STREAM_MAIN_CONF|NGX_STREAM_SRV_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_str_slot,
+      NGX_STREAM_SRV_CONF_OFFSET,
+      offsetof(ngx_stream_proxy_srv_conf_t, ssl_crl),
+      NULL },
+
+    { ngx_string("proxy_ssl_certificate"),
+      NGX_STREAM_MAIN_CONF|NGX_STREAM_SRV_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_str_slot,
+      NGX_STREAM_SRV_CONF_OFFSET,
+      offsetof(ngx_stream_proxy_srv_conf_t, ssl_certificate),
+      NULL },
+
+    { ngx_string("proxy_ssl_certificate_key"),
+      NGX_STREAM_MAIN_CONF|NGX_STREAM_SRV_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_str_slot,
+      NGX_STREAM_SRV_CONF_OFFSET,
+      offsetof(ngx_stream_proxy_srv_conf_t, ssl_certificate_key),
+      NULL },
+
+    { ngx_string("proxy_ssl_password_file"),
+      NGX_STREAM_MAIN_CONF|NGX_STREAM_SRV_CONF|NGX_CONF_TAKE1,
+      ngx_stream_proxy_ssl_password_file,
+      NGX_STREAM_SRV_CONF_OFFSET,
+      0,
+      NULL },
+
+#endif
+
+      ngx_null_command
+};
+
+
+static ngx_stream_module_t  ngx_stream_proxy_module_ctx = {
+    NULL,                                  /* preconfiguration */
+    NULL,                                  /* postconfiguration */
+
+    NULL,                                  /* create main configuration */
+    NULL,                                  /* init main configuration */
+
+    ngx_stream_proxy_create_srv_conf,      /* create server configuration */
+    ngx_stream_proxy_merge_srv_conf        /* merge server configuration */
+};
+
+
+ngx_module_t  ngx_stream_proxy_module = {
+    NGX_MODULE_V1,
+    &ngx_stream_proxy_module_ctx,          /* module context */
+    ngx_stream_proxy_commands,             /* module directives */
+    NGX_STREAM_MODULE,                     /* module type */
+    NULL,                                  /* init master */
+    NULL,                                  /* init module */
+    NULL,                                  /* init process */
+    NULL,                                  /* init thread */
+    NULL,                                  /* exit thread */
+    NULL,                                  /* exit process */
+    NULL,                                  /* exit master */
+    NGX_MODULE_V1_PADDING
+};
+
+
+static void
+ngx_stream_proxy_handler(ngx_stream_session_t *s)
+{
+    u_char                           *p;
+    ngx_str_t                        *host;
+    ngx_uint_t                        i;
+    ngx_connection_t                 *c;
+    ngx_resolver_ctx_t               *ctx, temp;
+    ngx_stream_upstream_t            *u;
+    ngx_stream_core_srv_conf_t       *cscf;
+    ngx_stream_proxy_srv_conf_t      *pscf;
+    ngx_stream_upstream_srv_conf_t   *uscf, **uscfp;
+    ngx_stream_upstream_main_conf_t  *umcf;
+
+    c = s->connection;
+
+    pscf = ngx_stream_get_module_srv_conf(s, ngx_stream_proxy_module);
+
+    ngx_log_debug0(NGX_LOG_DEBUG_STREAM, c->log, 0,
+                   "proxy connection handler");
+
+    u = ngx_pcalloc(c->pool, sizeof(ngx_stream_upstream_t));
+    if (u == NULL) {
+        ngx_stream_proxy_finalize(s, NGX_STREAM_INTERNAL_SERVER_ERROR);
+        return;
+    }
+
+    s->upstream = u;
+
+    s->log_handler = ngx_stream_proxy_log_error;
+
+    u->peer.log = c->log;
+    u->peer.log_error = NGX_ERROR_ERR;
+
+    if (ngx_stream_proxy_set_local(s, u, pscf->local) != NGX_OK) {
+        ngx_stream_proxy_finalize(s, NGX_STREAM_INTERNAL_SERVER_ERROR);
+        return;
+    }
+
+    u->peer.type = c->type;
+    u->start_sec = ngx_time();
+
+    c->write->handler = ngx_stream_proxy_downstream_handler;
+    c->read->handler = ngx_stream_proxy_downstream_handler;
+
+    s->upstream_states = ngx_array_create(c->pool, 1,
+                                          sizeof(ngx_stream_upstream_state_t));
+    if (s->upstream_states == NULL) {
+        ngx_stream_proxy_finalize(s, NGX_STREAM_INTERNAL_SERVER_ERROR);
+        return;
+    }
+
+    if (c->type == SOCK_STREAM) {
+        p = ngx_pnalloc(c->pool, pscf->buffer_size);
+        if (p == NULL) {
+            ngx_stream_proxy_finalize(s, NGX_STREAM_INTERNAL_SERVER_ERROR);
+            return;
+        }
+
+        u->downstream_buf.start = p;
+        u->downstream_buf.end = p + pscf->buffer_size;
+        u->downstream_buf.pos = p;
+        u->downstream_buf.last = p;
+
+        if (c->read->ready) {
+            ngx_post_event(c->read, &ngx_posted_events);
+        }
+    }
+
+    if (pscf->upstream_value) {
+        if (ngx_stream_proxy_eval(s, pscf) != NGX_OK) {
+            ngx_stream_proxy_finalize(s, NGX_STREAM_INTERNAL_SERVER_ERROR);
+            return;
+        }
+    }
+
+    if (u->resolved == NULL) {
+
+        uscf = pscf->upstream;
+
+    } else {
+
+#if (NGX_STREAM_SSL)
+        u->ssl_name = u->resolved->host;
+#endif
+
+        host = &u->resolved->host;
+
+        umcf = ngx_stream_get_module_main_conf(s, ngx_stream_upstream_module);
+
+        uscfp = umcf->upstreams.elts;
+
+        for (i = 0; i < umcf->upstreams.nelts; i++) {
+
+            uscf = uscfp[i];
+
+            if (uscf->host.len == host->len
+                && ((uscf->port == 0 && u->resolved->no_port)
+                     || uscf->port == u->resolved->port)
+                && ngx_strncasecmp(uscf->host.data, host->data, host->len) == 0)
+            {
+                goto found;
+            }
+        }
+
+        if (u->resolved->sockaddr) {
+
+            if (u->resolved->port == 0
+                && u->resolved->sockaddr->sa_family != AF_UNIX)
+            {
+                ngx_log_error(NGX_LOG_ERR, c->log, 0,
+                              "no port in upstream \"%V\"", host);
+                ngx_stream_proxy_finalize(s, NGX_STREAM_INTERNAL_SERVER_ERROR);
+                return;
+            }
+
+            if (ngx_stream_upstream_create_round_robin_peer(s, u->resolved)
+                != NGX_OK)
+            {
+                ngx_stream_proxy_finalize(s, NGX_STREAM_INTERNAL_SERVER_ERROR);
+                return;
+            }
+
+            ngx_stream_proxy_connect(s);
+
+            return;
+        }
+
+        if (u->resolved->port == 0) {
+            ngx_log_error(NGX_LOG_ERR, c->log, 0,
+                          "no port in upstream \"%V\"", host);
+            ngx_stream_proxy_finalize(s, NGX_STREAM_INTERNAL_SERVER_ERROR);
+            return;
+        }
+
+        temp.name = *host;
+
+        cscf = ngx_stream_get_module_srv_conf(s, ngx_stream_core_module);
+
+        ctx = ngx_resolve_start(cscf->resolver, &temp);
+        if (ctx == NULL) {
+            ngx_stream_proxy_finalize(s, NGX_STREAM_INTERNAL_SERVER_ERROR);
+            return;
+        }
+
+        if (ctx == NGX_NO_RESOLVER) {
+            ngx_log_error(NGX_LOG_ERR, c->log, 0,
+                          "no resolver defined to resolve %V", host);
+            ngx_stream_proxy_finalize(s, NGX_STREAM_INTERNAL_SERVER_ERROR);
+            return;
+        }
+
+        ctx->name = *host;
+        ctx->handler = ngx_stream_proxy_resolve_handler;
+        ctx->data = s;
+        ctx->timeout = cscf->resolver_timeout;
+
+        u->resolved->ctx = ctx;
+
+        if (ngx_resolve_name(ctx) != NGX_OK) {
+            u->resolved->ctx = NULL;
+            ngx_stream_proxy_finalize(s, NGX_STREAM_INTERNAL_SERVER_ERROR);
+            return;
+        }
+
+        return;
+    }
+
+found:
+
+    if (uscf == NULL) {
+        ngx_log_error(NGX_LOG_ALERT, c->log, 0, "no upstream configuration");
+        ngx_stream_proxy_finalize(s, NGX_STREAM_INTERNAL_SERVER_ERROR);
+        return;
+    }
+
+    u->upstream = uscf;
+
+#if (NGX_STREAM_SSL)
+    u->ssl_name = uscf->host;
+#endif
+
+    if (uscf->peer.init(s, uscf) != NGX_OK) {
+        ngx_stream_proxy_finalize(s, NGX_STREAM_INTERNAL_SERVER_ERROR);
+        return;
+    }
+
+    u->peer.start_time = ngx_current_msec;
+
+    if (pscf->next_upstream_tries
+        && u->peer.tries > pscf->next_upstream_tries)
+    {
+        u->peer.tries = pscf->next_upstream_tries;
+    }
+
+    ngx_stream_proxy_connect(s);
+}
+
+
+static ngx_int_t
+ngx_stream_proxy_eval(ngx_stream_session_t *s,
+    ngx_stream_proxy_srv_conf_t *pscf)
+{
+    ngx_str_t               host;
+    ngx_url_t               url;
+    ngx_stream_upstream_t  *u;
+
+    if (ngx_stream_complex_value(s, pscf->upstream_value, &host) != NGX_OK) {
+        return NGX_ERROR;
+    }
+
+    ngx_memzero(&url, sizeof(ngx_url_t));
+
+    url.url = host;
+    url.no_resolve = 1;
+
+    if (ngx_parse_url(s->connection->pool, &url) != NGX_OK) {
+        if (url.err) {
+            ngx_log_error(NGX_LOG_ERR, s->connection->log, 0,
+                          "%s in upstream \"%V\"", url.err, &url.url);
+        }
+
+        return NGX_ERROR;
+    }
+
+    u = s->upstream;
+
+    u->resolved = ngx_pcalloc(s->connection->pool,
+                              sizeof(ngx_stream_upstream_resolved_t));
+    if (u->resolved == NULL) {
+        return NGX_ERROR;
+    }
+
+    if (url.addrs) {
+        u->resolved->sockaddr = url.addrs[0].sockaddr;
+        u->resolved->socklen = url.addrs[0].socklen;
+        u->resolved->name = url.addrs[0].name;
+        u->resolved->naddrs = 1;
+    }
+
+    u->resolved->host = url.host;
+    u->resolved->port = url.port;
+    u->resolved->no_port = url.no_port;
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_stream_proxy_set_local(ngx_stream_session_t *s, ngx_stream_upstream_t *u,
+    ngx_stream_upstream_local_t *local)
+{
+    ngx_int_t    rc;
+    ngx_str_t    val;
+    ngx_addr_t  *addr;
+
+    if (local == NULL) {
+        u->peer.local = NULL;
+        return NGX_OK;
+    }
+
+#if (NGX_HAVE_TRANSPARENT_PROXY)
+    u->peer.transparent = local->transparent;
+#endif
+
+    if (local->value == NULL) {
+        u->peer.local = local->addr;
+        return NGX_OK;
+    }
+
+    if (ngx_stream_complex_value(s, local->value, &val) != NGX_OK) {
+        return NGX_ERROR;
+    }
+
+    if (val.len == 0) {
+        return NGX_OK;
+    }
+
+    addr = ngx_palloc(s->connection->pool, sizeof(ngx_addr_t));
+    if (addr == NULL) {
+        return NGX_ERROR;
+    }
+
+    rc = ngx_parse_addr_port(s->connection->pool, addr, val.data, val.len);
+    if (rc == NGX_ERROR) {
+        return NGX_ERROR;
+    }
+
+    if (rc != NGX_OK) {
+        ngx_log_error(NGX_LOG_ERR, s->connection->log, 0,
+                      "invalid local address \"%V\"", &val);
+        return NGX_OK;
+    }
+
+    addr->name = val;
+    u->peer.local = addr;
+
+    return NGX_OK;
+}
+
+
+static void
+ngx_stream_proxy_connect(ngx_stream_session_t *s)
+{
+    ngx_int_t                     rc;
+    ngx_connection_t             *c, *pc;
+    ngx_stream_upstream_t        *u;
+    ngx_stream_proxy_srv_conf_t  *pscf;
+
+    c = s->connection;
+
+    c->log->action = "connecting to upstream";
+
+    pscf = ngx_stream_get_module_srv_conf(s, ngx_stream_proxy_module);
+
+    u = s->upstream;
+
+    u->connected = 0;
+    u->proxy_protocol = pscf->proxy_protocol;
+
+    if (u->state) {
+        u->state->response_time = ngx_current_msec - u->state->response_time;
+    }
+
+    u->state = ngx_array_push(s->upstream_states);
+    if (u->state == NULL) {
+        ngx_stream_proxy_finalize(s, NGX_STREAM_INTERNAL_SERVER_ERROR);
+        return;
+    }
+
+    ngx_memzero(u->state, sizeof(ngx_stream_upstream_state_t));
+
+    u->state->connect_time = (ngx_msec_t) -1;
+    u->state->first_byte_time = (ngx_msec_t) -1;
+    u->state->response_time = ngx_current_msec;
+
+    rc = ngx_event_connect_peer(&u->peer);
+
+    ngx_log_debug1(NGX_LOG_DEBUG_STREAM, c->log, 0, "proxy connect: %i", rc);
+
+    if (rc == NGX_ERROR) {
+        ngx_stream_proxy_finalize(s, NGX_STREAM_INTERNAL_SERVER_ERROR);
+        return;
+    }
+
+    u->state->peer = u->peer.name;
+
+    if (rc == NGX_BUSY) {
+        ngx_log_error(NGX_LOG_ERR, c->log, 0, "no live upstreams");
+        ngx_stream_proxy_finalize(s, NGX_STREAM_BAD_GATEWAY);
+        return;
+    }
+
+    if (rc == NGX_DECLINED) {
+        ngx_stream_proxy_next_upstream(s);
+        return;
+    }
+
+    /* rc == NGX_OK || rc == NGX_AGAIN || rc == NGX_DONE */
+
+    pc = u->peer.connection;
+
+    pc->data = s;
+    pc->log = c->log;
+    pc->pool = c->pool;
+    pc->read->log = c->log;
+    pc->write->log = c->log;
+
+    if (rc != NGX_AGAIN) {
+        ngx_stream_proxy_init_upstream(s);
+        return;
+    }
+
+    pc->read->handler = ngx_stream_proxy_connect_handler;
+    pc->write->handler = ngx_stream_proxy_connect_handler;
+
+    ngx_add_timer(pc->write, pscf->connect_timeout);
+}
+
+
+static void
+ngx_stream_proxy_init_upstream(ngx_stream_session_t *s)
+{
+    u_char                       *p;
+    ngx_chain_t                  *cl;
+    ngx_connection_t             *c, *pc;
+    ngx_log_handler_pt            handler;
+    ngx_stream_upstream_t        *u;
+    ngx_stream_core_srv_conf_t   *cscf;
+    ngx_stream_proxy_srv_conf_t  *pscf;
+
+    u = s->upstream;
+    pc = u->peer.connection;
+
+    cscf = ngx_stream_get_module_srv_conf(s, ngx_stream_core_module);
+
+    if (pc->type == SOCK_STREAM
+        && cscf->tcp_nodelay
+        && ngx_tcp_nodelay(pc) != NGX_OK)
+    {
+        ngx_stream_proxy_next_upstream(s);
+        return;
+    }
+
+    pscf = ngx_stream_get_module_srv_conf(s, ngx_stream_proxy_module);
+
+#if (NGX_STREAM_SSL)
+
+    if (pc->type == SOCK_STREAM && pscf->ssl) {
+
+        if (u->proxy_protocol) {
+            if (ngx_stream_proxy_send_proxy_protocol(s) != NGX_OK) {
+                return;
+            }
+
+            u->proxy_protocol = 0;
+        }
+
+        if (pc->ssl == NULL) {
+            ngx_stream_proxy_ssl_init_connection(s);
+            return;
+        }
+    }
+
+#endif
+
+    c = s->connection;
+
+    if (c->log->log_level >= NGX_LOG_INFO) {
+        ngx_str_t  str;
+        u_char     addr[NGX_SOCKADDR_STRLEN];
+
+        str.len = NGX_SOCKADDR_STRLEN;
+        str.data = addr;
+
+        if (ngx_connection_local_sockaddr(pc, &str, 1) == NGX_OK) {
+            handler = c->log->handler;
+            c->log->handler = NULL;
+
+            ngx_log_error(NGX_LOG_INFO, c->log, 0,
+                          "%sproxy %V connected to %V",
+                          pc->type == SOCK_DGRAM ? "udp " : "",
+                          &str, u->peer.name);
+
+            c->log->handler = handler;
+        }
+    }
+
+    u->state->connect_time = ngx_current_msec - u->state->response_time;
+
+    if (u->peer.notify) {
+        u->peer.notify(&u->peer, u->peer.data,
+                       NGX_STREAM_UPSTREAM_NOTIFY_CONNECT);
+    }
+
+    c->log->action = "proxying connection";
+
+    if (u->upstream_buf.start == NULL) {
+        p = ngx_pnalloc(c->pool, pscf->buffer_size);
+        if (p == NULL) {
+            ngx_stream_proxy_finalize(s, NGX_STREAM_INTERNAL_SERVER_ERROR);
+            return;
+        }
+
+        u->upstream_buf.start = p;
+        u->upstream_buf.end = p + pscf->buffer_size;
+        u->upstream_buf.pos = p;
+        u->upstream_buf.last = p;
+    }
+
+    if (c->buffer && c->buffer->pos < c->buffer->last) {
+        ngx_log_debug1(NGX_LOG_DEBUG_STREAM, c->log, 0,
+                       "stream proxy add preread buffer: %uz",
+                       c->buffer->last - c->buffer->pos);
+
+        cl = ngx_chain_get_free_buf(c->pool, &u->free);
+        if (cl == NULL) {
+            ngx_stream_proxy_finalize(s, NGX_STREAM_INTERNAL_SERVER_ERROR);
+            return;
+        }
+
+        *cl->buf = *c->buffer;
+
+        cl->buf->tag = (ngx_buf_tag_t) &ngx_stream_proxy_module;
+        cl->buf->flush = 1;
+        cl->buf->last_buf = (c->type == SOCK_DGRAM);
+
+        cl->next = u->upstream_out;
+        u->upstream_out = cl;
+    }
+
+    if (u->proxy_protocol) {
+        ngx_log_debug0(NGX_LOG_DEBUG_STREAM, c->log, 0,
+                       "stream proxy add PROXY protocol header");
+
+        cl = ngx_chain_get_free_buf(c->pool, &u->free);
+        if (cl == NULL) {
+            ngx_stream_proxy_finalize(s, NGX_STREAM_INTERNAL_SERVER_ERROR);
+            return;
+        }
+
+        p = ngx_pnalloc(c->pool, NGX_PROXY_PROTOCOL_MAX_HEADER);
+        if (p == NULL) {
+            ngx_stream_proxy_finalize(s, NGX_STREAM_INTERNAL_SERVER_ERROR);
+            return;
+        }
+
+        cl->buf->pos = p;
+
+        p = ngx_proxy_protocol_write(c, p, p + NGX_PROXY_PROTOCOL_MAX_HEADER);
+        if (p == NULL) {
+            ngx_stream_proxy_finalize(s, NGX_STREAM_INTERNAL_SERVER_ERROR);
+            return;
+        }
+
+        cl->buf->last = p;
+        cl->buf->temporary = 1;
+        cl->buf->flush = 0;
+        cl->buf->last_buf = 0;
+        cl->buf->tag = (ngx_buf_tag_t) &ngx_stream_proxy_module;
+
+        cl->next = u->upstream_out;
+        u->upstream_out = cl;
+
+        u->proxy_protocol = 0;
+    }
+
+    if (c->type == SOCK_DGRAM && pscf->responses == 0) {
+        pc->read->ready = 0;
+        pc->read->eof = 1;
+    }
+
+    u->connected = 1;
+
+    pc->read->handler = ngx_stream_proxy_upstream_handler;
+    pc->write->handler = ngx_stream_proxy_upstream_handler;
+
+    if (pc->read->ready || pc->read->eof) {
+        ngx_post_event(pc->read, &ngx_posted_events);
+    }
+
+    ngx_stream_proxy_process(s, 0, 1);
+}
+
+
+#if (NGX_STREAM_SSL)
+
+static ngx_int_t
+ngx_stream_proxy_send_proxy_protocol(ngx_stream_session_t *s)
+{
+    u_char                       *p;
+    ssize_t                       n, size;
+    ngx_connection_t             *c, *pc;
+    ngx_stream_upstream_t        *u;
+    ngx_stream_proxy_srv_conf_t  *pscf;
+    u_char                        buf[NGX_PROXY_PROTOCOL_MAX_HEADER];
+
+    c = s->connection;
+
+    ngx_log_debug0(NGX_LOG_DEBUG_STREAM, c->log, 0,
+                   "stream proxy send PROXY protocol header");
+
+    p = ngx_proxy_protocol_write(c, buf, buf + NGX_PROXY_PROTOCOL_MAX_HEADER);
+    if (p == NULL) {
+        ngx_stream_proxy_finalize(s, NGX_STREAM_INTERNAL_SERVER_ERROR);
+        return NGX_ERROR;
+    }
+
+    u = s->upstream;
+
+    pc = u->peer.connection;
+
+    size = p - buf;
+
+    n = pc->send(pc, buf, size);
+
+    if (n == NGX_AGAIN) {
+        if (ngx_handle_write_event(pc->write, 0) != NGX_OK) {
+            ngx_stream_proxy_finalize(s, NGX_STREAM_INTERNAL_SERVER_ERROR);
+            return NGX_ERROR;
+        }
+
+        pscf = ngx_stream_get_module_srv_conf(s, ngx_stream_proxy_module);
+
+        ngx_add_timer(pc->write, pscf->timeout);
+
+        pc->write->handler = ngx_stream_proxy_connect_handler;
+
+        return NGX_AGAIN;
+    }
+
+    if (n == NGX_ERROR) {
+        ngx_stream_proxy_finalize(s, NGX_STREAM_OK);
+        return NGX_ERROR;
+    }
+
+    if (n != size) {
+
+        /*
+         * PROXY protocol specification:
+         * The sender must always ensure that the header
+         * is sent at once, so that the transport layer
+         * maintains atomicity along the path to the receiver.
+         */
+
+        ngx_log_error(NGX_LOG_ERR, c->log, 0,
+                      "could not send PROXY protocol header at once");
+
+        ngx_stream_proxy_finalize(s, NGX_STREAM_INTERNAL_SERVER_ERROR);
+
+        return NGX_ERROR;
+    }
+
+    return NGX_OK;
+}
+
+
+static char *
+ngx_stream_proxy_ssl_password_file(ngx_conf_t *cf, ngx_command_t *cmd,
+    void *conf)
+{
+    ngx_stream_proxy_srv_conf_t *pscf = conf;
+
+    ngx_str_t  *value;
+
+    if (pscf->ssl_passwords != NGX_CONF_UNSET_PTR) {
+        return "is duplicate";
+    }
+
+    value = cf->args->elts;
+
+    pscf->ssl_passwords = ngx_ssl_read_password_file(cf, &value[1]);
+
+    if (pscf->ssl_passwords == NULL) {
+        return NGX_CONF_ERROR;
+    }
+
+    return NGX_CONF_OK;
+}
+
+
+static void
+ngx_stream_proxy_ssl_init_connection(ngx_stream_session_t *s)
+{
+    ngx_int_t                     rc;
+    ngx_connection_t             *pc;
+    ngx_stream_upstream_t        *u;
+    ngx_stream_proxy_srv_conf_t  *pscf;
+
+    u = s->upstream;
+
+    pc = u->peer.connection;
+
+    pscf = ngx_stream_get_module_srv_conf(s, ngx_stream_proxy_module);
+
+    if (pscf->ssl_spiffe) {
+        if (!spiffe_thread_created) {
+            if (create_stream_spiffe_thread(pscf->ssl, 0, 1) != NGX_OK) {
+                ngx_stream_proxy_finalize(s, NGX_STREAM_INTERNAL_SERVER_ERROR);
+                return;
+            }
+            spiffe_thread_created = 1;
+        }
+        
+        while (is_stream_certificates_updated() != NGX_OK) {
+            // just wait
+            usleep(100000);
+        }
+    }
+
+    if (ngx_ssl_create_connection(pscf->ssl, pc, NGX_SSL_BUFFER|NGX_SSL_CLIENT)
+        != NGX_OK)
+    {
+        ngx_stream_proxy_finalize(s, NGX_STREAM_INTERNAL_SERVER_ERROR);
+        return;
+    }
+
+    if (pscf->ssl_server_name || pscf->ssl_verify) {
+        if (ngx_stream_proxy_ssl_name(s) != NGX_OK) {
+            ngx_stream_proxy_finalize(s, NGX_STREAM_INTERNAL_SERVER_ERROR);
+            return;
+        }
+    }
+
+    if (pscf->ssl_session_reuse) {
+        if (u->peer.set_session(&u->peer, u->peer.data) != NGX_OK) {
+            ngx_stream_proxy_finalize(s, NGX_STREAM_INTERNAL_SERVER_ERROR);
+            return;
+        }
+    }
+
+    s->connection->log->action = "SSL handshaking to upstream";
+
+    rc = ngx_ssl_handshake(pc);
+
+    if (rc == NGX_AGAIN) {
+
+        if (!pc->write->timer_set) {
+            ngx_add_timer(pc->write, pscf->connect_timeout);
+        }
+
+        pc->ssl->handler = ngx_stream_proxy_ssl_handshake;
+        return;
+    }
+
+    ngx_stream_proxy_ssl_handshake(pc);
+}
+
+
+static void
+ngx_stream_proxy_ssl_handshake(ngx_connection_t *pc)
+{
+    long                          rc;
+    ngx_stream_session_t         *s;
+    ngx_stream_upstream_t        *u;
+    ngx_stream_proxy_srv_conf_t  *pscf;
+
+    s = pc->data;
+
+    pscf = ngx_stream_get_module_srv_conf(s, ngx_stream_proxy_module);
+
+    if (pc->ssl->handshaked) {
+        // verify if spiffe validation is enabled
+        //
+        if (pscf->ssl_spiffe) {
+            // verify SPIFFE ID using accepted list
+            if (ngx_ssl_check_spiffe_id(pc, pscf->ssl_spiffe_accept)
+                != NGX_OK)
+            {
+                goto failed;
+            }
+            
+        }
+        
+        if (pscf->ssl_verify) {
+            rc = SSL_get_verify_result(pc->ssl->connection);
+
+            if (rc != X509_V_OK) {
+                ngx_log_error(NGX_LOG_ERR, pc->log, 0,
+                              "upstream SSL certificate verify error: (%l:%s)",
+                              rc, X509_verify_cert_error_string(rc));
+                goto failed;
+            }
+
+            u = s->upstream;
+
+            if (!pscf->ssl_spiffe && 
+                    ngx_ssl_check_host(pc, &u->ssl_name) != NGX_OK) {
+                ngx_log_error(NGX_LOG_ERR, pc->log, 0,
+                              "upstream SSL certificate does not match \"%V\"",
+                              &u->ssl_name);
+                goto failed;
+            }
+        }
+
+        if (pscf->ssl_session_reuse) {
+            u = s->upstream;
+            u->peer.save_session(&u->peer, u->peer.data);
+        }
+
+        if (pc->write->timer_set) {
+            ngx_del_timer(pc->write);
+        }
+
+        ngx_stream_proxy_init_upstream(s);
+
+        return;
+    }
+
+failed:
+
+    ngx_stream_proxy_next_upstream(s);
+}
+
+
+static ngx_int_t
+ngx_stream_proxy_ssl_name(ngx_stream_session_t *s)
+{
+    u_char                       *p, *last;
+    ngx_str_t                     name;
+    ngx_stream_upstream_t        *u;
+    ngx_stream_proxy_srv_conf_t  *pscf;
+
+    pscf = ngx_stream_get_module_srv_conf(s, ngx_stream_proxy_module);
+
+    u = s->upstream;
+
+    if (pscf->ssl_name) {
+        if (ngx_stream_complex_value(s, pscf->ssl_name, &name) != NGX_OK) {
+            return NGX_ERROR;
+        }
+
+    } else {
+        name = u->ssl_name;
+    }
+
+    if (name.len == 0) {
+        goto done;
+    }
+
+    /*
+     * ssl name here may contain port, strip it for compatibility
+     * with the http module
+     */
+
+    p = name.data;
+    last = name.data + name.len;
+
+    if (*p == '[') {
+        p = ngx_strlchr(p, last, ']');
+
+        if (p == NULL) {
+            p = name.data;
+        }
+    }
+
+    p = ngx_strlchr(p, last, ':');
+
+    if (p != NULL) {
+        name.len = p - name.data;
+    }
+
+    if (!pscf->ssl_server_name) {
+        goto done;
+    }
+
+#ifdef SSL_CTRL_SET_TLSEXT_HOSTNAME
+
+    /* as per RFC 6066, literal IPv4 and IPv6 addresses are not permitted */
+
+    if (name.len == 0 || *name.data == '[') {
+        goto done;
+    }
+
+    if (ngx_inet_addr(name.data, name.len) != INADDR_NONE) {
+        goto done;
+    }
+
+    /*
+     * SSL_set_tlsext_host_name() needs a null-terminated string,
+     * hence we explicitly null-terminate name here
+     */
+
+    p = ngx_pnalloc(s->connection->pool, name.len + 1);
+    if (p == NULL) {
+        return NGX_ERROR;
+    }
+
+    (void) ngx_cpystrn(p, name.data, name.len + 1);
+
+    name.data = p;
+
+    ngx_log_debug1(NGX_LOG_DEBUG_STREAM, s->connection->log, 0,
+                   "upstream SSL server name: \"%s\"", name.data);
+
+    if (SSL_set_tlsext_host_name(u->peer.connection->ssl->connection,
+                                 (char *) name.data)
+        == 0)
+    {
+        ngx_ssl_error(NGX_LOG_ERR, s->connection->log, 0,
+                      "SSL_set_tlsext_host_name(\"%s\") failed", name.data);
+        return NGX_ERROR;
+    }
+
+#endif
+
+done:
+
+    u->ssl_name = name;
+
+    return NGX_OK;
+}
+
+#endif
+
+
+static void
+ngx_stream_proxy_downstream_handler(ngx_event_t *ev)
+{
+    ngx_stream_proxy_process_connection(ev, ev->write);
+}
+
+
+static void
+ngx_stream_proxy_resolve_handler(ngx_resolver_ctx_t *ctx)
+{
+    ngx_stream_session_t            *s;
+    ngx_stream_upstream_t           *u;
+    ngx_stream_proxy_srv_conf_t     *pscf;
+    ngx_stream_upstream_resolved_t  *ur;
+
+    s = ctx->data;
+
+    u = s->upstream;
+    ur = u->resolved;
+
+    ngx_log_debug0(NGX_LOG_DEBUG_STREAM, s->connection->log, 0,
+                   "stream upstream resolve");
+
+    if (ctx->state) {
+        ngx_log_error(NGX_LOG_ERR, s->connection->log, 0,
+                      "%V could not be resolved (%i: %s)",
+                      &ctx->name, ctx->state,
+                      ngx_resolver_strerror(ctx->state));
+
+        ngx_stream_proxy_finalize(s, NGX_STREAM_INTERNAL_SERVER_ERROR);
+        return;
+    }
+
+    ur->naddrs = ctx->naddrs;
+    ur->addrs = ctx->addrs;
+
+#if (NGX_DEBUG)
+    {
+    u_char      text[NGX_SOCKADDR_STRLEN];
+    ngx_str_t   addr;
+    ngx_uint_t  i;
+
+    addr.data = text;
+
+    for (i = 0; i < ctx->naddrs; i++) {
+        addr.len = ngx_sock_ntop(ur->addrs[i].sockaddr, ur->addrs[i].socklen,
+                                 text, NGX_SOCKADDR_STRLEN, 0);
+
+        ngx_log_debug1(NGX_LOG_DEBUG_STREAM, s->connection->log, 0,
+                       "name was resolved to %V", &addr);
+    }
+    }
+#endif
+
+    if (ngx_stream_upstream_create_round_robin_peer(s, ur) != NGX_OK) {
+        ngx_stream_proxy_finalize(s, NGX_STREAM_INTERNAL_SERVER_ERROR);
+        return;
+    }
+
+    ngx_resolve_name_done(ctx);
+    ur->ctx = NULL;
+
+    u->peer.start_time = ngx_current_msec;
+
+    pscf = ngx_stream_get_module_srv_conf(s, ngx_stream_proxy_module);
+
+    if (pscf->next_upstream_tries
+        && u->peer.tries > pscf->next_upstream_tries)
+    {
+        u->peer.tries = pscf->next_upstream_tries;
+    }
+
+    ngx_stream_proxy_connect(s);
+}
+
+
+static void
+ngx_stream_proxy_upstream_handler(ngx_event_t *ev)
+{
+    ngx_stream_proxy_process_connection(ev, !ev->write);
+}
+
+
+static void
+ngx_stream_proxy_process_connection(ngx_event_t *ev, ngx_uint_t from_upstream)
+{
+    ngx_connection_t             *c, *pc;
+    ngx_stream_session_t         *s;
+    ngx_stream_upstream_t        *u;
+    ngx_stream_proxy_srv_conf_t  *pscf;
+
+    c = ev->data;
+    s = c->data;
+    u = s->upstream;
+
+    if (c->close) {
+        ngx_log_error(NGX_LOG_INFO, c->log, 0, "shutdown timeout");
+        ngx_stream_proxy_finalize(s, NGX_STREAM_OK);
+        return;
+    }
+
+    c = s->connection;
+    pc = u->peer.connection;
+
+    pscf = ngx_stream_get_module_srv_conf(s, ngx_stream_proxy_module);
+
+    if (ev->timedout) {
+        ev->timedout = 0;
+
+        if (ev->delayed) {
+            ev->delayed = 0;
+
+            if (!ev->ready) {
+                if (ngx_handle_read_event(ev, 0) != NGX_OK) {
+                    ngx_stream_proxy_finalize(s,
+                                              NGX_STREAM_INTERNAL_SERVER_ERROR);
+                    return;
+                }
+
+                if (u->connected && !c->read->delayed && !pc->read->delayed) {
+                    ngx_add_timer(c->write, pscf->timeout);
+                }
+
+                return;
+            }
+
+        } else {
+            if (s->connection->type == SOCK_DGRAM) {
+                if (pscf->responses == NGX_MAX_INT32_VALUE) {
+
+                    /*
+                     * successfully terminate timed out UDP session
+                     * with unspecified number of responses
+                     */
+
+                    pc->read->ready = 0;
+                    pc->read->eof = 1;
+
+                    ngx_stream_proxy_process(s, 1, 0);
+                    return;
+                }
+
+                ngx_connection_error(pc, NGX_ETIMEDOUT, "upstream timed out");
+
+                if (u->received == 0) {
+                    ngx_stream_proxy_next_upstream(s);
+                    return;
+                }
+
+            } else {
+                ngx_connection_error(c, NGX_ETIMEDOUT, "connection timed out");
+            }
+
+            ngx_stream_proxy_finalize(s, NGX_STREAM_OK);
+            return;
+        }
+
+    } else if (ev->delayed) {
+
+        ngx_log_debug0(NGX_LOG_DEBUG_STREAM, c->log, 0,
+                       "stream connection delayed");
+
+        if (ngx_handle_read_event(ev, 0) != NGX_OK) {
+            ngx_stream_proxy_finalize(s, NGX_STREAM_INTERNAL_SERVER_ERROR);
+        }
+
+        return;
+    }
+
+    if (from_upstream && !u->connected) {
+        return;
+    }
+
+    ngx_stream_proxy_process(s, from_upstream, ev->write);
+}
+
+
+static void
+ngx_stream_proxy_connect_handler(ngx_event_t *ev)
+{
+    ngx_connection_t      *c;
+    ngx_stream_session_t  *s;
+
+    c = ev->data;
+    s = c->data;
+
+    if (ev->timedout) {
+        ngx_log_error(NGX_LOG_ERR, c->log, NGX_ETIMEDOUT, "upstream timed out");
+        ngx_stream_proxy_next_upstream(s);
+        return;
+    }
+
+    ngx_del_timer(c->write);
+
+    ngx_log_debug0(NGX_LOG_DEBUG_STREAM, c->log, 0,
+                   "stream proxy connect upstream");
+
+    if (ngx_stream_proxy_test_connect(c) != NGX_OK) {
+        ngx_stream_proxy_next_upstream(s);
+        return;
+    }
+
+    ngx_stream_proxy_init_upstream(s);
+}
+
+
+static ngx_int_t
+ngx_stream_proxy_test_connect(ngx_connection_t *c)
+{
+    int        err;
+    socklen_t  len;
+
+#if (NGX_HAVE_KQUEUE)
+
+    if (ngx_event_flags & NGX_USE_KQUEUE_EVENT)  {
+        err = c->write->kq_errno ? c->write->kq_errno : c->read->kq_errno;
+
+        if (err) {
+            (void) ngx_connection_error(c, err,
+                                    "kevent() reported that connect() failed");
+            return NGX_ERROR;
+        }
+
+    } else
+#endif
+    {
+        err = 0;
+        len = sizeof(int);
+
+        /*
+         * BSDs and Linux return 0 and set a pending error in err
+         * Solaris returns -1 and sets errno
+         */
+
+        if (getsockopt(c->fd, SOL_SOCKET, SO_ERROR, (void *) &err, &len)
+            == -1)
+        {
+            err = ngx_socket_errno;
+        }
+
+        if (err) {
+            (void) ngx_connection_error(c, err, "connect() failed");
+            return NGX_ERROR;
+        }
+    }
+
+    return NGX_OK;
+}
+
+
+static void
+ngx_stream_proxy_process(ngx_stream_session_t *s, ngx_uint_t from_upstream,
+    ngx_uint_t do_write)
+{
+    off_t                        *received, limit;
+    size_t                        size, limit_rate;
+    ssize_t                       n;
+    ngx_buf_t                    *b;
+    ngx_int_t                     rc;
+    ngx_uint_t                    flags;
+    ngx_msec_t                    delay;
+    ngx_chain_t                  *cl, **ll, **out, **busy;
+    ngx_connection_t             *c, *pc, *src, *dst;
+    ngx_log_handler_pt            handler;
+    ngx_stream_upstream_t        *u;
+    ngx_stream_proxy_srv_conf_t  *pscf;
+
+    u = s->upstream;
+
+    c = s->connection;
+    pc = u->connected ? u->peer.connection : NULL;
+
+    if (c->type == SOCK_DGRAM && (ngx_terminate || ngx_exiting)) {
+
+        /* socket is already closed on worker shutdown */
+
+        handler = c->log->handler;
+        c->log->handler = NULL;
+
+        ngx_log_error(NGX_LOG_INFO, c->log, 0, "disconnected on shutdown");
+
+        c->log->handler = handler;
+
+        ngx_stream_proxy_finalize(s, NGX_STREAM_OK);
+        return;
+    }
+
+    pscf = ngx_stream_get_module_srv_conf(s, ngx_stream_proxy_module);
+
+    if (from_upstream) {
+        src = pc;
+        dst = c;
+        b = &u->upstream_buf;
+        limit_rate = pscf->download_rate;
+        received = &u->received;
+        out = &u->downstream_out;
+        busy = &u->downstream_busy;
+
+    } else {
+        src = c;
+        dst = pc;
+        b = &u->downstream_buf;
+        limit_rate = pscf->upload_rate;
+        received = &s->received;
+        out = &u->upstream_out;
+        busy = &u->upstream_busy;
+    }
+
+    for ( ;; ) {
+
+        if (do_write && dst) {
+
+            if (*out || *busy || dst->buffered) {
+                rc = ngx_stream_top_filter(s, *out, from_upstream);
+
+                if (rc == NGX_ERROR) {
+                    if (c->type == SOCK_DGRAM && !from_upstream) {
+                        ngx_stream_proxy_next_upstream(s);
+                        return;
+                    }
+
+                    ngx_stream_proxy_finalize(s, NGX_STREAM_OK);
+                    return;
+                }
+
+                ngx_chain_update_chains(c->pool, &u->free, busy, out,
+                                      (ngx_buf_tag_t) &ngx_stream_proxy_module);
+
+                if (*busy == NULL) {
+                    b->pos = b->start;
+                    b->last = b->start;
+                }
+            }
+        }
+
+        size = b->end - b->last;
+
+        if (size && src->read->ready && !src->read->delayed
+            && !src->read->error)
+        {
+            if (limit_rate) {
+                limit = (off_t) limit_rate * (ngx_time() - u->start_sec + 1)
+                        - *received;
+
+                if (limit <= 0) {
+                    src->read->delayed = 1;
+                    delay = (ngx_msec_t) (- limit * 1000 / limit_rate + 1);
+                    ngx_add_timer(src->read, delay);
+                    break;
+                }
+
+                if ((off_t) size > limit) {
+                    size = (size_t) limit;
+                }
+            }
+
+            n = src->recv(src, b->last, size);
+
+            if (n == NGX_AGAIN) {
+                break;
+            }
+
+            if (n == NGX_ERROR) {
+                if (c->type == SOCK_DGRAM && u->received == 0) {
+                    ngx_stream_proxy_next_upstream(s);
+                    return;
+                }
+
+                src->read->eof = 1;
+                n = 0;
+            }
+
+            if (n >= 0) {
+                if (limit_rate) {
+                    delay = (ngx_msec_t) (n * 1000 / limit_rate);
+
+                    if (delay > 0) {
+                        src->read->delayed = 1;
+                        ngx_add_timer(src->read, delay);
+                    }
+                }
+
+                if (from_upstream) {
+                    if (u->state->first_byte_time == (ngx_msec_t) -1) {
+                        u->state->first_byte_time = ngx_current_msec
+                                                    - u->state->response_time;
+                    }
+                }
+
+                if (c->type == SOCK_DGRAM && ++u->responses == pscf->responses)
+                {
+                    src->read->ready = 0;
+                    src->read->eof = 1;
+                }
+
+                for (ll = out; *ll; ll = &(*ll)->next) { /* void */ }
+
+                cl = ngx_chain_get_free_buf(c->pool, &u->free);
+                if (cl == NULL) {
+                    ngx_stream_proxy_finalize(s,
+                                              NGX_STREAM_INTERNAL_SERVER_ERROR);
+                    return;
+                }
+
+                *ll = cl;
+
+                cl->buf->pos = b->last;
+                cl->buf->last = b->last + n;
+                cl->buf->tag = (ngx_buf_tag_t) &ngx_stream_proxy_module;
+
+                cl->buf->temporary = (n ? 1 : 0);
+                cl->buf->last_buf = src->read->eof;
+                cl->buf->flush = 1;
+
+                *received += n;
+                b->last += n;
+                do_write = 1;
+
+                continue;
+            }
+        }
+
+        break;
+    }
+
+    if (src->read->eof && dst && (dst->read->eof || !dst->buffered)) {
+        handler = c->log->handler;
+        c->log->handler = NULL;
+
+        ngx_log_error(NGX_LOG_INFO, c->log, 0,
+                      "%s%s disconnected"
+                      ", bytes from/to client:%O/%O"
+                      ", bytes from/to upstream:%O/%O",
+                      src->type == SOCK_DGRAM ? "udp " : "",
+                      from_upstream ? "upstream" : "client",
+                      s->received, c->sent, u->received, pc ? pc->sent : 0);
+
+        c->log->handler = handler;
+
+        ngx_stream_proxy_finalize(s, NGX_STREAM_OK);
+        return;
+    }
+
+    flags = src->read->eof ? NGX_CLOSE_EVENT : 0;
+
+    if (!src->shared && ngx_handle_read_event(src->read, flags) != NGX_OK) {
+        ngx_stream_proxy_finalize(s, NGX_STREAM_INTERNAL_SERVER_ERROR);
+        return;
+    }
+
+    if (dst) {
+        if (!dst->shared && ngx_handle_write_event(dst->write, 0) != NGX_OK) {
+            ngx_stream_proxy_finalize(s, NGX_STREAM_INTERNAL_SERVER_ERROR);
+            return;
+        }
+
+        if (!c->read->delayed && !pc->read->delayed) {
+            ngx_add_timer(c->write, pscf->timeout);
+
+        } else if (c->write->timer_set) {
+            ngx_del_timer(c->write);
+        }
+    }
+}
+
+
+static void
+ngx_stream_proxy_next_upstream(ngx_stream_session_t *s)
+{
+    ngx_msec_t                    timeout;
+    ngx_connection_t             *pc;
+    ngx_stream_upstream_t        *u;
+    ngx_stream_proxy_srv_conf_t  *pscf;
+
+    ngx_log_debug0(NGX_LOG_DEBUG_STREAM, s->connection->log, 0,
+                   "stream proxy next upstream");
+
+    u = s->upstream;
+    pc = u->peer.connection;
+
+    if (pc && pc->buffered) {
+        ngx_log_error(NGX_LOG_ERR, s->connection->log, 0,
+                      "buffered data on next upstream");
+        ngx_stream_proxy_finalize(s, NGX_STREAM_INTERNAL_SERVER_ERROR);
+        return;
+    }
+
+    if (s->connection->type == SOCK_DGRAM) {
+        u->upstream_out = NULL;
+    }
+
+    if (u->peer.sockaddr) {
+        u->peer.free(&u->peer, u->peer.data, NGX_PEER_FAILED);
+        u->peer.sockaddr = NULL;
+    }
+
+    pscf = ngx_stream_get_module_srv_conf(s, ngx_stream_proxy_module);
+
+    timeout = pscf->next_upstream_timeout;
+
+    if (u->peer.tries == 0
+        || !pscf->next_upstream
+        || (timeout && ngx_current_msec - u->peer.start_time >= timeout))
+    {
+        ngx_stream_proxy_finalize(s, NGX_STREAM_BAD_GATEWAY);
+        return;
+    }
+
+    if (pc) {
+        ngx_log_debug1(NGX_LOG_DEBUG_STREAM, s->connection->log, 0,
+                       "close proxy upstream connection: %d", pc->fd);
+
+#if (NGX_STREAM_SSL)
+        if (pc->ssl) {
+            pc->ssl->no_wait_shutdown = 1;
+            pc->ssl->no_send_shutdown = 1;
+
+            (void) ngx_ssl_shutdown(pc);
+        }
+#endif
+
+        u->state->bytes_received = u->received;
+        u->state->bytes_sent = pc->sent;
+
+        ngx_close_connection(pc);
+        u->peer.connection = NULL;
+    }
+
+    ngx_stream_proxy_connect(s);
+}
+
+
+static void
+ngx_stream_proxy_finalize(ngx_stream_session_t *s, ngx_uint_t rc)
+{
+    ngx_connection_t       *pc;
+    ngx_stream_upstream_t  *u;
+
+    ngx_log_debug1(NGX_LOG_DEBUG_STREAM, s->connection->log, 0,
+                   "finalize stream proxy: %i", rc);
+
+    u = s->upstream;
+
+    if (u == NULL) {
+        goto noupstream;
+    }
+
+    if (u->resolved && u->resolved->ctx) {
+        ngx_resolve_name_done(u->resolved->ctx);
+        u->resolved->ctx = NULL;
+    }
+
+    pc = u->peer.connection;
+
+    if (u->state) {
+        u->state->response_time = ngx_current_msec - u->state->response_time;
+
+        if (pc) {
+            u->state->bytes_received = u->received;
+            u->state->bytes_sent = pc->sent;
+        }
+    }
+
+    if (u->peer.free && u->peer.sockaddr) {
+        u->peer.free(&u->peer, u->peer.data, 0);
+        u->peer.sockaddr = NULL;
+    }
+
+    if (pc) {
+        ngx_log_debug1(NGX_LOG_DEBUG_STREAM, s->connection->log, 0,
+                       "close stream proxy upstream connection: %d", pc->fd);
+
+#if (NGX_STREAM_SSL)
+        if (pc->ssl) {
+            pc->ssl->no_wait_shutdown = 1;
+            (void) ngx_ssl_shutdown(pc);
+        }
+#endif
+
+        ngx_close_connection(pc);
+        u->peer.connection = NULL;
+    }
+
+noupstream:
+
+    ngx_stream_finalize_session(s, rc);
+}
+
+
+static u_char *
+ngx_stream_proxy_log_error(ngx_log_t *log, u_char *buf, size_t len)
+{
+    u_char                 *p;
+    ngx_connection_t       *pc;
+    ngx_stream_session_t   *s;
+    ngx_stream_upstream_t  *u;
+
+    s = log->data;
+
+    u = s->upstream;
+
+    p = buf;
+
+    if (u->peer.name) {
+        p = ngx_snprintf(p, len, ", upstream: \"%V\"", u->peer.name);
+        len -= p - buf;
+    }
+
+    pc = u->peer.connection;
+
+    p = ngx_snprintf(p, len,
+                     ", bytes from/to client:%O/%O"
+                     ", bytes from/to upstream:%O/%O",
+                     s->received, s->connection->sent,
+                     u->received, pc ? pc->sent : 0);
+
+    return p;
+}
+
+
+static void *
+ngx_stream_proxy_create_srv_conf(ngx_conf_t *cf)
+{
+    ngx_stream_proxy_srv_conf_t  *conf;
+
+    conf = ngx_pcalloc(cf->pool, sizeof(ngx_stream_proxy_srv_conf_t));
+    if (conf == NULL) {
+        return NULL;
+    }
+
+    /*
+     * set by ngx_pcalloc():
+     *
+     *     conf->ssl_protocols = 0;
+     *     conf->ssl_ciphers = { 0, NULL };
+     *     conf->ssl_name = NULL;
+     *     conf->ssl_trusted_certificate = { 0, NULL };
+     *     conf->ssl_crl = { 0, NULL };
+     *     conf->ssl_certificate = { 0, NULL };
+     *     conf->ssl_certificate_key = { 0, NULL };
+     *
+     *     conf->ssl = NULL;
+     *     conf->upstream = NULL;
+     *     conf->upstream_value = NULL;
+     */
+
+    conf->connect_timeout = NGX_CONF_UNSET_MSEC;
+    conf->timeout = NGX_CONF_UNSET_MSEC;
+    conf->next_upstream_timeout = NGX_CONF_UNSET_MSEC;
+    conf->buffer_size = NGX_CONF_UNSET_SIZE;
+    conf->upload_rate = NGX_CONF_UNSET_SIZE;
+    conf->download_rate = NGX_CONF_UNSET_SIZE;
+    conf->responses = NGX_CONF_UNSET_UINT;
+    conf->next_upstream_tries = NGX_CONF_UNSET_UINT;
+    conf->next_upstream = NGX_CONF_UNSET;
+    conf->proxy_protocol = NGX_CONF_UNSET;
+    conf->local = NGX_CONF_UNSET_PTR;
+
+#if (NGX_STREAM_SSL)
+    conf->ssl_enable = NGX_CONF_UNSET;
+    conf->ssl_session_reuse = NGX_CONF_UNSET;
+    conf->ssl_server_name = NGX_CONF_UNSET;
+    conf->ssl_verify = NGX_CONF_UNSET;
+    conf->ssl_spiffe = NGX_CONF_UNSET;    
+    conf->ssl_spiffe_accept = NGX_CONF_UNSET_PTR;  
+    conf->ssl_verify_depth = NGX_CONF_UNSET_UINT;
+    conf->ssl_passwords = NGX_CONF_UNSET_PTR;
+#endif
+
+    return conf;
+}
+
+
+static char *
+ngx_stream_proxy_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
+{
+    ngx_stream_proxy_srv_conf_t *prev = parent;
+    ngx_stream_proxy_srv_conf_t *conf = child;
+
+    ngx_conf_merge_msec_value(conf->connect_timeout,
+                              prev->connect_timeout, 60000);
+
+    ngx_conf_merge_msec_value(conf->timeout,
+                              prev->timeout, 10 * 60000);
+
+    ngx_conf_merge_msec_value(conf->next_upstream_timeout,
+                              prev->next_upstream_timeout, 0);
+
+    ngx_conf_merge_size_value(conf->buffer_size,
+                              prev->buffer_size, 16384);
+
+    ngx_conf_merge_size_value(conf->upload_rate,
+                              prev->upload_rate, 0);
+
+    ngx_conf_merge_size_value(conf->download_rate,
+                              prev->download_rate, 0);
+
+    ngx_conf_merge_uint_value(conf->responses,
+                              prev->responses, NGX_MAX_INT32_VALUE);
+
+    ngx_conf_merge_uint_value(conf->next_upstream_tries,
+                              prev->next_upstream_tries, 0);
+
+    ngx_conf_merge_value(conf->next_upstream, prev->next_upstream, 1);
+
+    ngx_conf_merge_value(conf->proxy_protocol, prev->proxy_protocol, 0);
+
+    ngx_conf_merge_ptr_value(conf->local, prev->local, NULL);
+
+#if (NGX_STREAM_SSL)
+
+    ngx_conf_merge_value(conf->ssl_enable, prev->ssl_enable, 0);
+
+    ngx_conf_merge_value(conf->ssl_session_reuse,
+                              prev->ssl_session_reuse, 1);
+
+    ngx_conf_merge_bitmask_value(conf->ssl_protocols, prev->ssl_protocols,
+                              (NGX_CONF_BITMASK_SET|NGX_SSL_TLSv1
+                               |NGX_SSL_TLSv1_1|NGX_SSL_TLSv1_2));
+
+    ngx_conf_merge_str_value(conf->ssl_ciphers, prev->ssl_ciphers, "DEFAULT");
+
+    if (conf->ssl_name == NULL) {
+        conf->ssl_name = prev->ssl_name;
+    }
+
+    ngx_conf_merge_value(conf->ssl_server_name, prev->ssl_server_name, 0);
+
+    ngx_conf_merge_value(conf->ssl_verify, prev->ssl_verify, 0);
+
+    ngx_conf_merge_value(conf->ssl_spiffe, prev->ssl_spiffe, 0);
+    
+    ngx_conf_merge_ptr_value(conf->ssl_spiffe_accept,
+                              prev->ssl_spiffe_accept, NULL);
+
+    ngx_conf_merge_uint_value(conf->ssl_verify_depth,
+                              prev->ssl_verify_depth, 1);
+
+    ngx_conf_merge_str_value(conf->ssl_trusted_certificate,
+                              prev->ssl_trusted_certificate, "");
+
+    ngx_conf_merge_str_value(conf->ssl_crl, prev->ssl_crl, "");
+
+    ngx_conf_merge_str_value(conf->ssl_certificate,
+                              prev->ssl_certificate, "");
+
+    ngx_conf_merge_str_value(conf->ssl_certificate_key,
+                              prev->ssl_certificate_key, "");
+
+    ngx_conf_merge_ptr_value(conf->ssl_passwords, prev->ssl_passwords, NULL);
+
+    if (conf->ssl_enable && ngx_stream_proxy_set_ssl(cf, conf) != NGX_OK) {
+        return NGX_CONF_ERROR;
+    }
+
+#endif
+
+    return NGX_CONF_OK;
+}
+
+
+#if (NGX_STREAM_SSL)
+
+static ngx_int_t
+ngx_stream_proxy_set_ssl(ngx_conf_t *cf, ngx_stream_proxy_srv_conf_t *pscf)
+{
+    ngx_pool_cleanup_t  *cln;
+
+    pscf->ssl = ngx_pcalloc(cf->pool, sizeof(ngx_ssl_t));
+    if (pscf->ssl == NULL) {
+        return NGX_ERROR;
+    }
+
+    pscf->ssl->log = cf->log;
+
+    if (ngx_ssl_create(pscf->ssl, pscf->ssl_protocols, NULL) != NGX_OK) {
+        return NGX_ERROR;
+    }
+
+    cln = ngx_pool_cleanup_add(cf->pool, 0);
+    if (cln == NULL) {
+        return NGX_ERROR;
+    }
+
+    cln->handler = ngx_ssl_cleanup_ctx;
+    cln->data = pscf->ssl;
+
+    // Avoid using files when SPIFFE ID validation is enabled.
+    //
+    if (!pscf->ssl_spiffe && pscf->ssl_certificate.len) {
+        
+        if (pscf->ssl_certificate_key.len == 0) {
+            ngx_log_error(NGX_LOG_EMERG, cf->log, 0,
+                          "no \"proxy_ssl_certificate_key\" is defined "
+                          "for certificate \"%V\"", &pscf->ssl_certificate);
+            return NGX_ERROR;
+        }
+
+        if (ngx_ssl_certificate(cf, pscf->ssl, &pscf->ssl_certificate,
+                                &pscf->ssl_certificate_key, pscf->ssl_passwords)
+            != NGX_OK)
+        {
+            return NGX_ERROR;
+        }
+    }
+
+    if (ngx_ssl_ciphers(cf, pscf->ssl, &pscf->ssl_ciphers, 0) != NGX_OK) {
+        return NGX_ERROR;
+    }
+
+    if (pscf->ssl_verify) {
+        if (!pscf->ssl_spiffe) {
+            if (pscf->ssl_trusted_certificate.len == 0) {
+                ngx_log_error(NGX_LOG_EMERG, cf->log, 0,
+                        "no proxy_ssl_trusted_certificate for proxy_ssl_verify");
+                return NGX_ERROR;
+            }
+
+            if (ngx_ssl_trusted_certificate(cf, pscf->ssl,
+                                            &pscf->ssl_trusted_certificate,
+                                            pscf->ssl_verify_depth)
+                != NGX_OK)
+            {
+                return NGX_ERROR;
+            }
+        }
+
+        if (ngx_ssl_crl(cf, pscf->ssl, &pscf->ssl_crl) != NGX_OK) {
+            return NGX_ERROR;
+        }
+    }
+
+    return NGX_OK;
+}
+
+#endif
+
+
+static char *
+ngx_stream_proxy_pass(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
+{
+    ngx_stream_proxy_srv_conf_t *pscf = conf;
+
+    ngx_url_t                            u;
+    ngx_str_t                           *value, *url;
+    ngx_stream_complex_value_t           cv;
+    ngx_stream_core_srv_conf_t          *cscf;
+    ngx_stream_compile_complex_value_t   ccv;
+
+    if (pscf->upstream || pscf->upstream_value) {
+        return "is duplicate";
+    }
+
+    cscf = ngx_stream_conf_get_module_srv_conf(cf, ngx_stream_core_module);
+
+    cscf->handler = ngx_stream_proxy_handler;
+
+    value = cf->args->elts;
+
+    url = &value[1];
+
+    ngx_memzero(&ccv, sizeof(ngx_stream_compile_complex_value_t));
+
+    ccv.cf = cf;
+    ccv.value = url;
+    ccv.complex_value = &cv;
+
+    if (ngx_stream_compile_complex_value(&ccv) != NGX_OK) {
+        return NGX_CONF_ERROR;
+    }
+
+    if (cv.lengths) {
+        pscf->upstream_value = ngx_palloc(cf->pool,
+                                          sizeof(ngx_stream_complex_value_t));
+        if (pscf->upstream_value == NULL) {
+            return NGX_CONF_ERROR;
+        }
+
+        *pscf->upstream_value = cv;
+
+        return NGX_CONF_OK;
+    }
+
+    ngx_memzero(&u, sizeof(ngx_url_t));
+
+    u.url = *url;
+    u.no_resolve = 1;
+
+    pscf->upstream = ngx_stream_upstream_add(cf, &u, 0);
+    if (pscf->upstream == NULL) {
+        return NGX_CONF_ERROR;
+    }
+
+    return NGX_CONF_OK;
+}
+
+
+static char *
+ngx_stream_proxy_bind(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
+{
+    ngx_stream_proxy_srv_conf_t *pscf = conf;
+
+    ngx_int_t                            rc;
+    ngx_str_t                           *value;
+    ngx_stream_complex_value_t           cv;
+    ngx_stream_upstream_local_t         *local;
+    ngx_stream_compile_complex_value_t   ccv;
+
+    if (pscf->local != NGX_CONF_UNSET_PTR) {
+        return "is duplicate";
+    }
+
+    value = cf->args->elts;
+
+    if (cf->args->nelts == 2 && ngx_strcmp(value[1].data, "off") == 0) {
+        pscf->local = NULL;
+        return NGX_CONF_OK;
+    }
+
+    ngx_memzero(&ccv, sizeof(ngx_stream_compile_complex_value_t));
+
+    ccv.cf = cf;
+    ccv.value = &value[1];
+    ccv.complex_value = &cv;
+
+    if (ngx_stream_compile_complex_value(&ccv) != NGX_OK) {
+        return NGX_CONF_ERROR;
+    }
+
+    local = ngx_pcalloc(cf->pool, sizeof(ngx_stream_upstream_local_t));
+    if (local == NULL) {
+        return NGX_CONF_ERROR;
+    }
+
+    pscf->local = local;
+
+    if (cv.lengths) {
+        local->value = ngx_palloc(cf->pool, sizeof(ngx_stream_complex_value_t));
+        if (local->value == NULL) {
+            return NGX_CONF_ERROR;
+        }
+
+        *local->value = cv;
+
+    } else {
+        local->addr = ngx_palloc(cf->pool, sizeof(ngx_addr_t));
+        if (local->addr == NULL) {
+            return NGX_CONF_ERROR;
+        }
+
+        rc = ngx_parse_addr_port(cf->pool, local->addr, value[1].data,
+                                 value[1].len);
+
+        switch (rc) {
+        case NGX_OK:
+            local->addr->name = value[1];
+            break;
+
+        case NGX_DECLINED:
+            ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                               "invalid address \"%V\"", &value[1]);
+            /* fall through */
+
+        default:
+            return NGX_CONF_ERROR;
+        }
+    }
+
+    if (cf->args->nelts > 2) {
+        if (ngx_strcmp(value[2].data, "transparent") == 0) {
+#if (NGX_HAVE_TRANSPARENT_PROXY)
+            ngx_core_conf_t  *ccf;
+
+            ccf = (ngx_core_conf_t *) ngx_get_conf(cf->cycle->conf_ctx,
+                                                   ngx_core_module);
+
+            ccf->transparent = 1;
+            local->transparent = 1;
+#else
+            ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                               "transparent proxying is not supported "
+                               "on this platform, ignored");
+#endif
+        } else {
+            ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                               "invalid parameter \"%V\"", &value[2]);
+            return NGX_CONF_ERROR;
+        }
+    }
+
+    return NGX_CONF_OK;
+}

--- a/spiffe-support/src/stream/ngx_stream_ssl_module.c
+++ b/spiffe-support/src/stream/ngx_stream_ssl_module.c
@@ -1,0 +1,918 @@
+
+/*
+ * Copyright (C) Igor Sysoev
+ * Copyright (C) Nginx, Inc.
+ */
+
+
+#include <ngx_config.h>
+#include <ngx_core.h>
+#include <ngx_stream.h>
+
+static int spiffe_thread_created = 0;
+
+typedef ngx_int_t (*ngx_ssl_variable_handler_pt)(ngx_connection_t *c,
+    ngx_pool_t *pool, ngx_str_t *s);
+
+
+#define NGX_DEFAULT_CIPHERS     "HIGH:!aNULL:!MD5"
+#define NGX_DEFAULT_ECDH_CURVE  "auto"
+
+
+static ngx_int_t ngx_stream_ssl_handler(ngx_stream_session_t *s);
+static ngx_int_t ngx_stream_ssl_init_connection(ngx_ssl_t *ssl,
+    ngx_connection_t *c);
+static void ngx_stream_ssl_handshake_handler(ngx_connection_t *c);
+static ngx_int_t ngx_stream_ssl_static_variable(ngx_stream_session_t *s,
+    ngx_stream_variable_value_t *v, uintptr_t data);
+static ngx_int_t ngx_stream_ssl_variable(ngx_stream_session_t *s,
+    ngx_stream_variable_value_t *v, uintptr_t data);
+
+static ngx_int_t ngx_stream_ssl_add_variables(ngx_conf_t *cf);
+static void *ngx_stream_ssl_create_conf(ngx_conf_t *cf);
+static char *ngx_stream_ssl_merge_conf(ngx_conf_t *cf, void *parent,
+    void *child);
+
+static char *ngx_stream_ssl_password_file(ngx_conf_t *cf, ngx_command_t *cmd,
+    void *conf);
+static char *ngx_stream_ssl_session_cache(ngx_conf_t *cf, ngx_command_t *cmd,
+    void *conf);
+static ngx_int_t ngx_stream_ssl_init(ngx_conf_t *cf);
+
+
+static ngx_conf_bitmask_t  ngx_stream_ssl_protocols[] = {
+    { ngx_string("SSLv2"), NGX_SSL_SSLv2 },
+    { ngx_string("SSLv3"), NGX_SSL_SSLv3 },
+    { ngx_string("TLSv1"), NGX_SSL_TLSv1 },
+    { ngx_string("TLSv1.1"), NGX_SSL_TLSv1_1 },
+    { ngx_string("TLSv1.2"), NGX_SSL_TLSv1_2 },
+    { ngx_string("TLSv1.3"), NGX_SSL_TLSv1_3 },
+    { ngx_null_string, 0 }
+};
+
+
+static ngx_conf_enum_t  ngx_stream_ssl_verify[] = {
+    { ngx_string("off"), 0 },
+    { ngx_string("on"), 1 },
+    { ngx_string("optional"), 2 },
+    { ngx_string("optional_no_ca"), 3 },
+    { ngx_null_string, 0 }
+};
+
+
+static ngx_command_t  ngx_stream_ssl_commands[] = {
+
+    { ngx_string("ssl_handshake_timeout"),
+      NGX_STREAM_MAIN_CONF|NGX_STREAM_SRV_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_msec_slot,
+      NGX_STREAM_SRV_CONF_OFFSET,
+      offsetof(ngx_stream_ssl_conf_t, handshake_timeout),
+      NULL },
+
+    { ngx_string("ssl_certificate"),
+      NGX_STREAM_MAIN_CONF|NGX_STREAM_SRV_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_str_array_slot,
+      NGX_STREAM_SRV_CONF_OFFSET,
+      offsetof(ngx_stream_ssl_conf_t, certificates),
+      NULL },
+
+    { ngx_string("ssl_certificate_key"),
+      NGX_STREAM_MAIN_CONF|NGX_STREAM_SRV_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_str_array_slot,
+      NGX_STREAM_SRV_CONF_OFFSET,
+      offsetof(ngx_stream_ssl_conf_t, certificate_keys),
+      NULL },
+
+    { ngx_string("ssl_password_file"),
+      NGX_STREAM_MAIN_CONF|NGX_STREAM_SRV_CONF|NGX_CONF_TAKE1,
+      ngx_stream_ssl_password_file,
+      NGX_STREAM_SRV_CONF_OFFSET,
+      0,
+      NULL },
+
+    { ngx_string("ssl_dhparam"),
+      NGX_STREAM_MAIN_CONF|NGX_STREAM_SRV_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_str_slot,
+      NGX_STREAM_SRV_CONF_OFFSET,
+      offsetof(ngx_stream_ssl_conf_t, dhparam),
+      NULL },
+
+    { ngx_string("ssl_ecdh_curve"),
+      NGX_STREAM_MAIN_CONF|NGX_STREAM_SRV_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_str_slot,
+      NGX_STREAM_SRV_CONF_OFFSET,
+      offsetof(ngx_stream_ssl_conf_t, ecdh_curve),
+      NULL },
+
+    { ngx_string("ssl_protocols"),
+      NGX_STREAM_MAIN_CONF|NGX_STREAM_SRV_CONF|NGX_CONF_1MORE,
+      ngx_conf_set_bitmask_slot,
+      NGX_STREAM_SRV_CONF_OFFSET,
+      offsetof(ngx_stream_ssl_conf_t, protocols),
+      &ngx_stream_ssl_protocols },
+
+    { ngx_string("ssl_ciphers"),
+      NGX_STREAM_MAIN_CONF|NGX_STREAM_SRV_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_str_slot,
+      NGX_STREAM_SRV_CONF_OFFSET,
+      offsetof(ngx_stream_ssl_conf_t, ciphers),
+      NULL },
+
+    { ngx_string("ssl_verify_client"),
+      NGX_STREAM_MAIN_CONF|NGX_STREAM_SRV_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_enum_slot,
+      NGX_STREAM_SRV_CONF_OFFSET,
+      offsetof(ngx_stream_ssl_conf_t, verify),
+      &ngx_stream_ssl_verify },
+
+    { ngx_string("ssl_verify_depth"),
+      NGX_STREAM_MAIN_CONF|NGX_STREAM_SRV_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_num_slot,
+      NGX_STREAM_SRV_CONF_OFFSET,
+      offsetof(ngx_stream_ssl_conf_t, verify_depth),
+      NULL },
+
+    { ngx_string("ssl_client_certificate"),
+      NGX_STREAM_MAIN_CONF|NGX_STREAM_SRV_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_str_slot,
+      NGX_STREAM_SRV_CONF_OFFSET,
+      offsetof(ngx_stream_ssl_conf_t, client_certificate),
+      NULL },
+
+    { ngx_string("ssl_trusted_certificate"),
+      NGX_STREAM_MAIN_CONF|NGX_STREAM_SRV_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_str_slot,
+      NGX_STREAM_SRV_CONF_OFFSET,
+      offsetof(ngx_stream_ssl_conf_t, trusted_certificate),
+      NULL },
+
+    { ngx_string("ssl_prefer_server_ciphers"),
+      NGX_STREAM_MAIN_CONF|NGX_STREAM_SRV_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot,
+      NGX_STREAM_SRV_CONF_OFFSET,
+      offsetof(ngx_stream_ssl_conf_t, prefer_server_ciphers),
+      NULL },
+
+    { ngx_string("ssl_session_cache"),
+      NGX_STREAM_MAIN_CONF|NGX_STREAM_SRV_CONF|NGX_CONF_TAKE12,
+      ngx_stream_ssl_session_cache,
+      NGX_STREAM_SRV_CONF_OFFSET,
+      0,
+      NULL },
+
+    { ngx_string("ssl_session_tickets"),
+      NGX_STREAM_MAIN_CONF|NGX_STREAM_SRV_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot,
+      NGX_STREAM_SRV_CONF_OFFSET,
+      offsetof(ngx_stream_ssl_conf_t, session_tickets),
+      NULL },
+
+    { ngx_string("ssl_session_ticket_key"),
+      NGX_STREAM_MAIN_CONF|NGX_STREAM_SRV_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_str_array_slot,
+      NGX_STREAM_SRV_CONF_OFFSET,
+      offsetof(ngx_stream_ssl_conf_t, session_ticket_keys),
+      NULL },
+
+    { ngx_string("ssl_session_timeout"),
+      NGX_STREAM_MAIN_CONF|NGX_STREAM_SRV_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_sec_slot,
+      NGX_STREAM_SRV_CONF_OFFSET,
+      offsetof(ngx_stream_ssl_conf_t, session_timeout),
+      NULL },
+
+    { ngx_string("ssl_crl"),
+      NGX_STREAM_MAIN_CONF|NGX_STREAM_SRV_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_str_slot,
+      NGX_STREAM_SRV_CONF_OFFSET,
+      offsetof(ngx_stream_ssl_conf_t, crl),
+      NULL },
+    { ngx_string("ssl_spiffe"),		
+      NGX_STREAM_MAIN_CONF|NGX_STREAM_SRV_CONF|NGX_CONF_FLAG,		
+      ngx_conf_set_flag_slot,		
+      NGX_STREAM_SRV_CONF_OFFSET,		
+      offsetof(ngx_stream_ssl_conf_t, ssl_spiffe),		
+      NULL },	
+    { ngx_string("ssl_spiffe_accept"),		
+      NGX_STREAM_MAIN_CONF|NGX_STREAM_SRV_CONF|(NGX_CONF_TAKE1|NGX_CONF_TAKE2|NGX_CONF_TAKE3   \
+                |NGX_CONF_TAKE4|NGX_CONF_TAKE5|NGX_CONF_TAKE6|NGX_CONF_TAKE7),		
+      ngx_conf_set_spiffe_accept_slot,		
+      NGX_STREAM_SRV_CONF_OFFSET,		
+      offsetof(ngx_stream_ssl_conf_t, ssl_spiffe_accept),		
+      NULL },
+
+      ngx_null_command
+};
+
+
+static ngx_stream_module_t  ngx_stream_ssl_module_ctx = {
+    ngx_stream_ssl_add_variables,          /* preconfiguration */
+    ngx_stream_ssl_init,                   /* postconfiguration */
+
+    NULL,                                  /* create main configuration */
+    NULL,                                  /* init main configuration */
+
+    ngx_stream_ssl_create_conf,            /* create server configuration */
+    ngx_stream_ssl_merge_conf              /* merge server configuration */
+};
+
+
+ngx_module_t  ngx_stream_ssl_module = {
+    NGX_MODULE_V1,
+    &ngx_stream_ssl_module_ctx,            /* module context */
+    ngx_stream_ssl_commands,               /* module directives */
+    NGX_STREAM_MODULE,                     /* module type */
+    NULL,                                  /* init master */
+    NULL,                                  /* init module */
+    NULL,                                  /* init process */
+    NULL,                                  /* init thread */
+    NULL,                                  /* exit thread */
+    NULL,                                  /* exit process */
+    NULL,                                  /* exit master */
+    NGX_MODULE_V1_PADDING
+};
+
+
+static ngx_stream_variable_t  ngx_stream_ssl_vars[] = {
+
+    { ngx_string("ssl_protocol"), NULL, ngx_stream_ssl_static_variable,
+      (uintptr_t) ngx_ssl_get_protocol, NGX_STREAM_VAR_CHANGEABLE, 0 },
+
+    { ngx_string("ssl_cipher"), NULL, ngx_stream_ssl_static_variable,
+      (uintptr_t) ngx_ssl_get_cipher_name, NGX_STREAM_VAR_CHANGEABLE, 0 },
+
+    { ngx_string("ssl_ciphers"), NULL, ngx_stream_ssl_variable,
+      (uintptr_t) ngx_ssl_get_ciphers, NGX_STREAM_VAR_CHANGEABLE, 0 },
+
+    { ngx_string("ssl_curves"), NULL, ngx_stream_ssl_variable,
+      (uintptr_t) ngx_ssl_get_curves, NGX_STREAM_VAR_CHANGEABLE, 0 },
+
+    { ngx_string("ssl_session_id"), NULL, ngx_stream_ssl_variable,
+      (uintptr_t) ngx_ssl_get_session_id, NGX_STREAM_VAR_CHANGEABLE, 0 },
+
+    { ngx_string("ssl_session_reused"), NULL, ngx_stream_ssl_variable,
+      (uintptr_t) ngx_ssl_get_session_reused, NGX_STREAM_VAR_CHANGEABLE, 0 },
+
+    { ngx_string("ssl_server_name"), NULL, ngx_stream_ssl_variable,
+      (uintptr_t) ngx_ssl_get_server_name, NGX_STREAM_VAR_CHANGEABLE, 0 },
+
+    { ngx_string("ssl_client_cert"), NULL, ngx_stream_ssl_variable,
+      (uintptr_t) ngx_ssl_get_certificate, NGX_STREAM_VAR_CHANGEABLE, 0 },
+
+    { ngx_string("ssl_client_raw_cert"), NULL, ngx_stream_ssl_variable,
+      (uintptr_t) ngx_ssl_get_raw_certificate,
+      NGX_STREAM_VAR_CHANGEABLE, 0 },
+
+    { ngx_string("ssl_client_escaped_cert"), NULL, ngx_stream_ssl_variable,
+      (uintptr_t) ngx_ssl_get_escaped_certificate,
+      NGX_STREAM_VAR_CHANGEABLE, 0 },
+
+    { ngx_string("ssl_client_s_dn"), NULL, ngx_stream_ssl_variable,
+      (uintptr_t) ngx_ssl_get_subject_dn, NGX_STREAM_VAR_CHANGEABLE, 0 },
+
+    { ngx_string("ssl_client_i_dn"), NULL, ngx_stream_ssl_variable,
+      (uintptr_t) ngx_ssl_get_issuer_dn, NGX_STREAM_VAR_CHANGEABLE, 0 },
+
+    { ngx_string("ssl_client_serial"), NULL, ngx_stream_ssl_variable,
+      (uintptr_t) ngx_ssl_get_serial_number, NGX_STREAM_VAR_CHANGEABLE, 0 },
+
+    { ngx_string("ssl_client_fingerprint"), NULL, ngx_stream_ssl_variable,
+      (uintptr_t) ngx_ssl_get_fingerprint, NGX_STREAM_VAR_CHANGEABLE, 0 },
+
+    { ngx_string("ssl_client_verify"), NULL, ngx_stream_ssl_variable,
+      (uintptr_t) ngx_ssl_get_client_verify, NGX_STREAM_VAR_CHANGEABLE, 0 },
+
+    { ngx_string("ssl_client_v_start"), NULL, ngx_stream_ssl_variable,
+      (uintptr_t) ngx_ssl_get_client_v_start, NGX_STREAM_VAR_CHANGEABLE, 0 },
+
+    { ngx_string("ssl_client_v_end"), NULL, ngx_stream_ssl_variable,
+      (uintptr_t) ngx_ssl_get_client_v_end, NGX_STREAM_VAR_CHANGEABLE, 0 },
+
+    { ngx_string("ssl_client_v_remain"), NULL, ngx_stream_ssl_variable,
+      (uintptr_t) ngx_ssl_get_client_v_remain, NGX_STREAM_VAR_CHANGEABLE, 0 },
+
+      ngx_stream_null_variable
+};
+
+
+static ngx_str_t ngx_stream_ssl_sess_id_ctx = ngx_string("STREAM");
+
+
+static ngx_int_t
+ngx_stream_ssl_handler(ngx_stream_session_t *s)
+{
+    long                    rc;
+    X509                   *cert;
+    ngx_int_t               rv;
+    ngx_connection_t       *c;
+    ngx_stream_ssl_conf_t  *sslcf;
+
+    if (!s->ssl) {
+        return NGX_OK;
+    }
+
+    c = s->connection;
+
+    sslcf = ngx_stream_get_module_srv_conf(s, ngx_stream_ssl_module);
+
+    if (sslcf->ssl_spiffe) {
+        if (!spiffe_thread_created) {
+            if (create_stream_spiffe_thread(&sslcf->ssl, 1, sslcf->verify_depth) != NGX_OK) {
+                return NGX_ERROR;
+            }
+            spiffe_thread_created = 1;
+        }
+        
+        while (is_stream_certificates_updated() != NGX_OK) {
+            // just wait
+            usleep(100000);
+        }
+    }
+
+    if (c->ssl == NULL) {
+        c->log->action = "SSL handshaking";
+
+        if (sslcf->ssl.ctx == NULL) {
+            ngx_log_error(NGX_LOG_ERR, c->log, 0,
+                          "no \"ssl_certificate\" is defined "
+                          "in server listening on SSL port");
+            return NGX_ERROR;
+        }
+
+        rv = ngx_stream_ssl_init_connection(&sslcf->ssl, c);
+
+        if (rv != NGX_OK) {
+            return rv;
+        }
+    }
+
+    if (sslcf->verify) {
+        rc = SSL_get_verify_result(c->ssl->connection);
+
+        if (rc != X509_V_OK
+            && (sslcf->verify != 3 || !ngx_ssl_verify_error_optional(rc)))
+        {
+            ngx_log_error(NGX_LOG_INFO, c->log, 0,
+                          "client SSL certificate verify error: (%l:%s)",
+                          rc, X509_verify_cert_error_string(rc));
+
+            ngx_ssl_remove_cached_session(c->ssl->session_ctx,
+                                       (SSL_get0_session(c->ssl->connection)));
+            return NGX_ERROR;
+        }
+
+        if (sslcf->verify == 1) {
+            cert = SSL_get_peer_certificate(c->ssl->connection);
+
+            if (cert == NULL) {
+                ngx_log_error(NGX_LOG_INFO, c->log, 0,
+                              "client sent no required SSL certificate");
+
+                ngx_ssl_remove_cached_session(c->ssl->session_ctx,
+                                       (SSL_get0_session(c->ssl->connection)));
+                return NGX_ERROR;
+            }
+
+            if (sslcf->ssl_spiffe == 1) {
+                ASN1_STRING             *str;
+                GENERAL_NAME            *sanName;
+                STACK_OF(GENERAL_NAME)  *san_names = NULL;
+
+                san_names = X509_get_ext_d2i((X509 *) cert, NID_subject_alt_name, NULL, NULL);
+                sanName = sk_GENERAL_NAME_value(san_names, 0); 
+                str = sanName->d.dNSName;
+
+                if (!ngx_is_spiffe_id_accepted(str->data, sslcf->ssl_spiffe_accept)) {
+                    ngx_log_error(NGX_LOG_ERR, c->log, 0,
+                                "SPIFFE ID is not allowed: \"%s\",", str->data);
+
+                    ngx_ssl_remove_cached_session(c->ssl->session_ctx,
+                                        (SSL_get0_session(c->ssl->connection)));
+
+                    return NGX_ERROR;
+                    
+                }                      
+          
+            }
+
+            X509_free(cert);
+        }
+    }
+    
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_stream_ssl_init_connection(ngx_ssl_t *ssl, ngx_connection_t *c)
+{
+    ngx_int_t                    rc;
+    ngx_stream_session_t        *s;
+    ngx_stream_ssl_conf_t       *sslcf;
+    ngx_stream_core_srv_conf_t  *cscf;
+
+    s = c->data;
+
+    cscf = ngx_stream_get_module_srv_conf(s, ngx_stream_core_module);
+
+    if (cscf->tcp_nodelay && ngx_tcp_nodelay(c) != NGX_OK) {
+        return NGX_ERROR;
+    }
+
+    if (ngx_ssl_create_connection(ssl, c, 0) != NGX_OK) {
+        return NGX_ERROR;
+    }
+
+    rc = ngx_ssl_handshake(c);
+
+    if (rc == NGX_ERROR) {
+        return NGX_ERROR;
+    }
+
+    if (rc == NGX_AGAIN) {
+        sslcf = ngx_stream_get_module_srv_conf(s, ngx_stream_ssl_module);
+
+        ngx_add_timer(c->read, sslcf->handshake_timeout);
+
+        c->ssl->handler = ngx_stream_ssl_handshake_handler;
+
+        return NGX_AGAIN;
+    }
+
+    /* rc == NGX_OK */
+
+    return NGX_OK;
+}
+
+
+static void
+ngx_stream_ssl_handshake_handler(ngx_connection_t *c)
+{
+    ngx_stream_session_t  *s;
+
+    s = c->data;
+
+    if (!c->ssl->handshaked) {
+        ngx_stream_finalize_session(s, NGX_STREAM_INTERNAL_SERVER_ERROR);
+        return;
+    }
+
+    if (c->read->timer_set) {
+        ngx_del_timer(c->read);
+    }
+
+    ngx_stream_core_run_phases(s);
+}
+
+
+static ngx_int_t
+ngx_stream_ssl_static_variable(ngx_stream_session_t *s,
+    ngx_stream_variable_value_t *v, uintptr_t data)
+{
+    ngx_ssl_variable_handler_pt  handler = (ngx_ssl_variable_handler_pt) data;
+
+    size_t     len;
+    ngx_str_t  str;
+
+    if (s->connection->ssl) {
+
+        (void) handler(s->connection, NULL, &str);
+
+        v->data = str.data;
+
+        for (len = 0; v->data[len]; len++) { /* void */ }
+
+        v->len = len;
+        v->valid = 1;
+        v->no_cacheable = 0;
+        v->not_found = 0;
+
+        return NGX_OK;
+    }
+
+    v->not_found = 1;
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_stream_ssl_variable(ngx_stream_session_t *s,
+    ngx_stream_variable_value_t *v, uintptr_t data)
+{
+    ngx_ssl_variable_handler_pt  handler = (ngx_ssl_variable_handler_pt) data;
+
+    ngx_str_t  str;
+
+    if (s->connection->ssl) {
+
+        if (handler(s->connection, s->connection->pool, &str) != NGX_OK) {
+            return NGX_ERROR;
+        }
+
+        v->len = str.len;
+        v->data = str.data;
+
+        if (v->len) {
+            v->valid = 1;
+            v->no_cacheable = 0;
+            v->not_found = 0;
+
+            return NGX_OK;
+        }
+    }
+
+    v->not_found = 1;
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_stream_ssl_add_variables(ngx_conf_t *cf)
+{
+    ngx_stream_variable_t  *var, *v;
+
+    for (v = ngx_stream_ssl_vars; v->name.len; v++) {
+        var = ngx_stream_add_variable(cf, &v->name, v->flags);
+        if (var == NULL) {
+            return NGX_ERROR;
+        }
+
+        var->get_handler = v->get_handler;
+        var->data = v->data;
+    }
+
+    return NGX_OK;
+}
+
+
+static void *
+ngx_stream_ssl_create_conf(ngx_conf_t *cf)
+{
+    ngx_stream_ssl_conf_t  *scf;
+
+    scf = ngx_pcalloc(cf->pool, sizeof(ngx_stream_ssl_conf_t));
+    if (scf == NULL) {
+        return NULL;
+    }
+
+    /*
+     * set by ngx_pcalloc():
+     *
+     *     scf->protocols = 0;
+     *     scf->dhparam = { 0, NULL };
+     *     scf->ecdh_curve = { 0, NULL };
+     *     scf->client_certificate = { 0, NULL };
+     *     scf->trusted_certificate = { 0, NULL };
+     *     scf->crl = { 0, NULL };
+     *     scf->ciphers = { 0, NULL };
+     *     scf->shm_zone = NULL;
+     */
+
+    scf->handshake_timeout = NGX_CONF_UNSET_MSEC;
+    scf->certificates = NGX_CONF_UNSET_PTR;
+    scf->certificate_keys = NGX_CONF_UNSET_PTR;
+    scf->passwords = NGX_CONF_UNSET_PTR;
+    scf->prefer_server_ciphers = NGX_CONF_UNSET;
+    scf->verify = NGX_CONF_UNSET_UINT;
+    scf->verify_depth = NGX_CONF_UNSET_UINT;
+    scf->builtin_session_cache = NGX_CONF_UNSET;
+    scf->session_timeout = NGX_CONF_UNSET;
+    scf->session_tickets = NGX_CONF_UNSET;
+    scf->session_ticket_keys = NGX_CONF_UNSET_PTR;
+    scf->ssl_spiffe = NGX_CONF_UNSET;		
+    scf->ssl_spiffe_accept = NGX_CONF_UNSET_PTR;
+
+    return scf;
+}
+
+
+static char *
+ngx_stream_ssl_merge_conf(ngx_conf_t *cf, void *parent, void *child)
+{
+    ngx_stream_ssl_conf_t *prev = parent;
+    ngx_stream_ssl_conf_t *conf = child;
+
+    ngx_pool_cleanup_t  *cln;
+
+    ngx_conf_merge_msec_value(conf->handshake_timeout,
+                         prev->handshake_timeout, 60000);
+
+    ngx_conf_merge_value(conf->session_timeout,
+                         prev->session_timeout, 300);
+
+    ngx_conf_merge_value(conf->prefer_server_ciphers,
+                         prev->prefer_server_ciphers, 0);
+
+    ngx_conf_merge_bitmask_value(conf->protocols, prev->protocols,
+                         (NGX_CONF_BITMASK_SET|NGX_SSL_TLSv1
+                          |NGX_SSL_TLSv1_1|NGX_SSL_TLSv1_2));
+
+    ngx_conf_merge_uint_value(conf->verify, prev->verify, 0);
+
+    ngx_conf_merge_value(conf->ssl_spiffe, 		
+                         prev->ssl_spiffe, 0);		
+    ngx_conf_merge_ptr_value(conf->ssl_spiffe_accept,		
+                         prev->ssl_spiffe_accept, NULL);
+
+    ngx_conf_merge_uint_value(conf->verify_depth, prev->verify_depth, 1);
+
+    ngx_conf_merge_ptr_value(conf->certificates, prev->certificates, NULL);
+    ngx_conf_merge_ptr_value(conf->certificate_keys, prev->certificate_keys,
+                         NULL);
+
+    ngx_conf_merge_ptr_value(conf->passwords, prev->passwords, NULL);
+
+    ngx_conf_merge_str_value(conf->dhparam, prev->dhparam, "");
+
+    ngx_conf_merge_str_value(conf->client_certificate, prev->client_certificate,
+                         "");
+    ngx_conf_merge_str_value(conf->trusted_certificate,
+                         prev->trusted_certificate, "");
+    ngx_conf_merge_str_value(conf->crl, prev->crl, "");
+
+    ngx_conf_merge_str_value(conf->ecdh_curve, prev->ecdh_curve,
+                         NGX_DEFAULT_ECDH_CURVE);
+
+    ngx_conf_merge_str_value(conf->ciphers, prev->ciphers, NGX_DEFAULT_CIPHERS);
+
+
+    conf->ssl.log = cf->log;
+ 
+    // If SPIFFE is disabled, and certs are no provided, tcp will no use certificates
+    //
+    if (!conf->ssl_spiffe && conf->certificates == NULL) {
+        return NGX_CONF_OK;
+    }
+
+    // Certificates are no required when SPIFFE is enabled.
+    //
+    if (!conf->ssl_spiffe) {
+        if (conf->certificate_keys == NULL
+            || conf->certificate_keys->nelts < conf->certificates->nelts)
+        {
+            ngx_log_error(NGX_LOG_EMERG, cf->log, 0,
+                        "no \"ssl_certificate_key\" is defined "
+                        "for certificate \"%V\"",
+                        ((ngx_str_t *) conf->certificates->elts)
+                        + conf->certificates->nelts - 1);
+            return NGX_CONF_ERROR;
+        }
+    }
+
+    if (ngx_ssl_create(&conf->ssl, conf->protocols, NULL) != NGX_OK) {
+        return NGX_CONF_ERROR;
+    }
+
+    cln = ngx_pool_cleanup_add(cf->pool, 0);
+    if (cln == NULL) {
+        return NGX_CONF_ERROR;
+    }
+
+    cln->handler = ngx_ssl_cleanup_ctx;
+    cln->data = &conf->ssl;
+
+    // No use provided certificates from configuration when SPIFFE is enabled.
+    //
+    if (!conf->ssl_spiffe && 
+            ngx_ssl_certificates(cf, &conf->ssl, conf->certificates,
+                            conf->certificate_keys, conf->passwords)
+        != NGX_OK)
+    {
+        return NGX_CONF_ERROR;
+    }
+
+    if (ngx_ssl_ciphers(cf, &conf->ssl, &conf->ciphers,
+                        conf->prefer_server_ciphers)
+        != NGX_OK)
+    {
+        return NGX_CONF_ERROR;
+    }
+
+    if (conf->verify) {
+        if (!conf->ssl_spiffe) {
+            if (conf->client_certificate.len == 0 && conf->verify != 3) {
+                ngx_log_error(NGX_LOG_EMERG, cf->log, 0,
+                            "no ssl_client_certificate for ssl_client_verify");
+                return NGX_CONF_ERROR;
+            }
+
+            if (ngx_ssl_client_certificate(cf, &conf->ssl,
+                                        &conf->client_certificate,
+                                        conf->verify_depth)
+                != NGX_OK)
+            {
+                return NGX_CONF_ERROR;
+            }
+        
+            if (ngx_ssl_trusted_certificate(cf, &conf->ssl,
+                                            &conf->trusted_certificate,
+                                            conf->verify_depth)
+                != NGX_OK)
+            {
+                return NGX_CONF_ERROR;
+            }
+        }
+        if (ngx_ssl_crl(cf, &conf->ssl, &conf->crl) != NGX_OK) {
+            return NGX_CONF_ERROR;
+        }
+    }
+
+    if (ngx_ssl_dhparam(cf, &conf->ssl, &conf->dhparam) != NGX_OK) {
+        return NGX_CONF_ERROR;
+    }
+
+    if (ngx_ssl_ecdh_curve(cf, &conf->ssl, &conf->ecdh_curve) != NGX_OK) {
+        return NGX_CONF_ERROR;
+    }
+
+    ngx_conf_merge_value(conf->builtin_session_cache,
+                        prev->builtin_session_cache, NGX_SSL_NONE_SCACHE);
+
+    if (conf->shm_zone == NULL) {
+        conf->shm_zone = prev->shm_zone;
+    }
+
+    if (ngx_ssl_session_cache(&conf->ssl, &ngx_stream_ssl_sess_id_ctx,
+                            conf->builtin_session_cache,
+                            conf->shm_zone, conf->session_timeout)
+        != NGX_OK)
+    {
+        return NGX_CONF_ERROR;
+    }
+    
+    ngx_conf_merge_value(conf->session_tickets,
+                         prev->session_tickets, 1);
+
+#ifdef SSL_OP_NO_TICKET
+    if (!conf->session_tickets) {
+        SSL_CTX_set_options(conf->ssl.ctx, SSL_OP_NO_TICKET);
+    }
+#endif
+
+    ngx_conf_merge_ptr_value(conf->session_ticket_keys,
+                         prev->session_ticket_keys, NULL);
+
+    if (ngx_ssl_session_ticket_keys(cf, &conf->ssl, conf->session_ticket_keys)
+        != NGX_OK)
+    {
+        return NGX_CONF_ERROR;
+    }
+
+    return NGX_CONF_OK;
+}
+
+
+static char *
+ngx_stream_ssl_password_file(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
+{
+    ngx_stream_ssl_conf_t  *scf = conf;
+
+    ngx_str_t  *value;
+
+    if (scf->passwords != NGX_CONF_UNSET_PTR) {
+        return "is duplicate";
+    }
+
+    value = cf->args->elts;
+
+    scf->passwords = ngx_ssl_read_password_file(cf, &value[1]);
+
+    if (scf->passwords == NULL) {
+        return NGX_CONF_ERROR;
+    }
+
+    return NGX_CONF_OK;
+}
+
+
+static char *
+ngx_stream_ssl_session_cache(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
+{
+    ngx_stream_ssl_conf_t  *scf = conf;
+
+    size_t       len;
+    ngx_str_t   *value, name, size;
+    ngx_int_t    n;
+    ngx_uint_t   i, j;
+
+    value = cf->args->elts;
+
+    for (i = 1; i < cf->args->nelts; i++) {
+
+        if (ngx_strcmp(value[i].data, "off") == 0) {
+            scf->builtin_session_cache = NGX_SSL_NO_SCACHE;
+            continue;
+        }
+
+        if (ngx_strcmp(value[i].data, "none") == 0) {
+            scf->builtin_session_cache = NGX_SSL_NONE_SCACHE;
+            continue;
+        }
+
+        if (ngx_strcmp(value[i].data, "builtin") == 0) {
+            scf->builtin_session_cache = NGX_SSL_DFLT_BUILTIN_SCACHE;
+            continue;
+        }
+
+        if (value[i].len > sizeof("builtin:") - 1
+            && ngx_strncmp(value[i].data, "builtin:", sizeof("builtin:") - 1)
+               == 0)
+        {
+            n = ngx_atoi(value[i].data + sizeof("builtin:") - 1,
+                         value[i].len - (sizeof("builtin:") - 1));
+
+            if (n == NGX_ERROR) {
+                goto invalid;
+            }
+
+            scf->builtin_session_cache = n;
+
+            continue;
+        }
+
+        if (value[i].len > sizeof("shared:") - 1
+            && ngx_strncmp(value[i].data, "shared:", sizeof("shared:") - 1)
+               == 0)
+        {
+            len = 0;
+
+            for (j = sizeof("shared:") - 1; j < value[i].len; j++) {
+                if (value[i].data[j] == ':') {
+                    break;
+                }
+
+                len++;
+            }
+
+            if (len == 0) {
+                goto invalid;
+            }
+
+            name.len = len;
+            name.data = value[i].data + sizeof("shared:") - 1;
+
+            size.len = value[i].len - j - 1;
+            size.data = name.data + len + 1;
+
+            n = ngx_parse_size(&size);
+
+            if (n == NGX_ERROR) {
+                goto invalid;
+            }
+
+            if (n < (ngx_int_t) (8 * ngx_pagesize)) {
+                ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                                   "session cache \"%V\" is too small",
+                                   &value[i]);
+
+                return NGX_CONF_ERROR;
+            }
+
+            scf->shm_zone = ngx_shared_memory_add(cf, &name, n,
+                                                   &ngx_stream_ssl_module);
+            if (scf->shm_zone == NULL) {
+                return NGX_CONF_ERROR;
+            }
+
+            scf->shm_zone->init = ngx_ssl_session_cache_init;
+
+            continue;
+        }
+
+        goto invalid;
+    }
+
+    if (scf->shm_zone && scf->builtin_session_cache == NGX_CONF_UNSET) {
+        scf->builtin_session_cache = NGX_SSL_NO_BUILTIN_SCACHE;
+    }
+
+    return NGX_CONF_OK;
+
+invalid:
+
+    ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                       "invalid session cache \"%V\"", &value[i]);
+
+    return NGX_CONF_ERROR;
+}
+
+
+static ngx_int_t
+ngx_stream_ssl_init(ngx_conf_t *cf)
+{
+    ngx_stream_handler_pt        *h;
+    ngx_stream_core_main_conf_t  *cmcf;
+
+    cmcf = ngx_stream_conf_get_module_main_conf(cf, ngx_stream_core_module);
+
+    h = ngx_array_push(&cmcf->phases[NGX_STREAM_SSL_PHASE].handlers);
+    if (h == NULL) {
+        return NGX_ERROR;
+    }
+
+    *h = ngx_stream_ssl_handler;
+
+    return NGX_OK;
+}

--- a/spiffe-support/src/stream/ngx_stream_ssl_module.h
+++ b/spiffe-support/src/stream/ngx_stream_ssl_module.h
@@ -47,7 +47,7 @@ typedef struct {
 
     ngx_flag_t       session_tickets;
     ngx_array_t     *session_ticket_keys;
-    ngx_flag_t 		 ssl_spiffe;		
+    ngx_flag_t       ssl_spiffe;
     ngx_array_t 	*ssl_spiffe_accept;
 } ngx_stream_ssl_conf_t;
 

--- a/spiffe-support/src/stream/ngx_stream_ssl_module.h
+++ b/spiffe-support/src/stream/ngx_stream_ssl_module.h
@@ -1,0 +1,62 @@
+
+/*
+ * Copyright (C) Igor Sysoev
+ * Copyright (C) Nginx, Inc.
+ */
+
+
+#ifndef _NGX_STREAM_SSL_H_INCLUDED_
+#define _NGX_STREAM_SSL_H_INCLUDED_
+
+
+#include <ngx_config.h>
+#include <ngx_core.h>
+#include <ngx_stream.h>
+
+
+typedef struct {
+    ngx_msec_t       handshake_timeout;
+
+    ngx_flag_t       prefer_server_ciphers;
+
+    ngx_ssl_t        ssl;
+
+    ngx_uint_t       protocols;
+
+    ngx_uint_t       verify;
+    ngx_uint_t       verify_depth;
+
+    ssize_t          builtin_session_cache;
+
+    time_t           session_timeout;
+
+    ngx_array_t     *certificates;
+    ngx_array_t     *certificate_keys;
+
+    ngx_str_t        dhparam;
+    ngx_str_t        ecdh_curve;
+    ngx_str_t        client_certificate;
+    ngx_str_t        trusted_certificate;
+    ngx_str_t        crl;
+
+    ngx_str_t        ciphers;
+
+    ngx_array_t     *passwords;
+
+    ngx_shm_zone_t  *shm_zone;
+
+    ngx_flag_t       session_tickets;
+    ngx_array_t     *session_ticket_keys;
+    ngx_flag_t 		 ssl_spiffe;		
+    ngx_array_t 	*ssl_spiffe_accept;
+} ngx_stream_ssl_conf_t;
+
+
+extern ngx_module_t  ngx_stream_ssl_module;
+
+
+#endif /* _NGX_STREAM_SSL_H_INCLUDED_ */
+
+
+ngx_int_t create_stream_spiffe_thread(ngx_ssl_t *ssl, ngx_flag_t is_client, ngx_int_t depth);
+ngx_int_t is_stream_certificates_updated();


### PR DESCRIPTION
This PR adds TCP proxying capabilities to spiffe-nginx by modifying the nginx stream module.
Also, some refactoring was done in spiffe certs modules.

Fixes issue #9 

Signed-off-by: Marcos G. Yedro <marcosyedro@gmail.com>